### PR TITLE
refactor: avoid innerHTML clearing

### DIFF
--- a/public/js/components/showProperties.js
+++ b/public/js/components/showProperties.js
@@ -296,7 +296,7 @@ function showProperties(element, modeling, moddle, currentUser) {
 
   const fieldsToShow = FIELD_DEFINITIONS.filter(f => fieldKeys.includes(f.key));
 
-  propsSidebar.innerHTML = '';
+  propsSidebar.replaceChildren();
   if (propsSidebar._unsubTheme) {
     propsSidebar._unsubTheme();
   }
@@ -365,7 +365,7 @@ function showProperties(element, modeling, moddle, currentUser) {
   
   
   function renderAddOnsList() {
-  addOnsListContainer.innerHTML = '';
+    addOnsListContainer.replaceChildren();
 
   if (!currentAddOns.length) {
     const emptyMsg = document.createElement('p');


### PR DESCRIPTION
## Summary
- replace props sidebar `innerHTML` clearing with `replaceChildren`
- use `replaceChildren` for AddOns list rendering

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b6eded8808328a55e522e19184ca5