### PR TITLE
feat: add token simulation toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,10 @@
   <link rel="stylesheet"
         href="https://unpkg.com/bpmn-js@18.6.2/dist/assets/bpmn-font/css/bpmn.css" />
 
+  <!-- Token simulation plugin CSS -->
+  <link rel="stylesheet"
+        href="https://unpkg.com/bpmn-js-token-simulation@0.31.0/dist/assets/token-simulation.css" />
+
   <style>
   html, body, #canvas, #palette {
     height: 100%;
@@ -52,6 +56,8 @@
 
   <!-- 3) Modeler UMD bundle (this defines window.BpmnJS) -->
   <script src="https://unpkg.com/bpmn-js@18.6.2/dist/bpmn-modeler.development.js"></script>
+  <!-- Token simulation plugin -->
+  <script src="https://unpkg.com/bpmn-js-token-simulation@0.31.0/dist/bpmn-js-token-simulation.umd.js"></script>
   <!-- 4) auto-layout + navigator -->
   <script src="https://unpkg.com/bpmn-auto-layout@0.4.0/dist/bpmn-auto-layout.umd.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@bpmn-io/navigator@1.0.0/dist/bpmn-navigator.umd.js"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -66,6 +66,7 @@ Object.assign(document.body.style, {
   const { BpmnJS }       = window;
   const layoutProcess    = window.bpmnAutoLayout?.layoutProcess;
   const NavigatorModule  = window.NavigatorModule;
+  const tokenSimulationModule = window['bpmn-js-token-simulation'];
 
   // ─── build canvas + xml-editor elements ────────────────────────────────────
   // REPLACE with this:
@@ -90,10 +91,14 @@ Object.assign(document.body.style, {
   // ─── instantiate modeler with navigator only ───────────────────────────────
   const navModule = window.navigatorModule || window.bpmnNavigator;
 
+  const additionalModules = [];
+  if (navModule) additionalModules.push(navModule);
+  if (tokenSimulationModule) additionalModules.push(tokenSimulationModule);
+
   const modeler = new BpmnJS({
     container:       canvasEl,
     selection:       { mode: 'multiple' },
-    additionalModules: navModule ? [ navModule ] : []
+    additionalModules
     });
   const eventBus     = modeler.get('eventBus');
   const commandStack = modeler.get('commandStack');
@@ -646,10 +651,19 @@ function rebuildMenu() {
           a.click();
         });
       };
-    }, { outline: true, title: "Download as PNG" }),
-    saveBtn,    
-    // ─── Continuous Zoom Outfinally theme selector
-    themedThemeSelector()
+      }, { outline: true, title: "Download as PNG" }),
+      // ─── Token simulation toggle ───────────────────────────────────────────
+      reactiveButton(
+        new Stream("▶"),
+        () => {
+          const simulation = modeler.get('tokenSimulation');
+          if (simulation) simulation.toggle();
+        },
+        { outline: true, title: "Toggle Token Simulation" }
+      ),
+      saveBtn,
+      // ─── Continuous Zoom Outfinally theme selector
+      themedThemeSelector()
 
   ], {
     justify: 'flex-start',


### PR DESCRIPTION
## Summary
- load bpmn-js-token-simulation plugin and stylesheet
- wire token simulation module into modeler
- add play button to toggle token animation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b75ab6bf4832885e3a76544c37fb6