### PR TITLE
Handle optional token simulation module

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -66,7 +66,8 @@ Object.assign(document.body.style, {
   const { BpmnJS }       = window;
   const layoutProcess    = window.bpmnAutoLayout?.layoutProcess;
   const NavigatorModule  = window.NavigatorModule;
-  const tokenSimulationModule = window['bpmn-js-token-simulation'];
+  // try both possible globals exposed by the UMD bundle
+  const tokenSimulationModule = window.BpmnJSTokenSimulation || window['bpmn-js-token-simulation'];
 
   // ─── build canvas + xml-editor elements ────────────────────────────────────
   // REPLACE with this:
@@ -93,7 +94,10 @@ Object.assign(document.body.style, {
 
   const additionalModules = [];
   if (navModule) additionalModules.push(navModule);
-  if (tokenSimulationModule) additionalModules.push(tokenSimulationModule);
+  if (tokenSimulationModule) {
+    // UMD build may expose the module on `default`
+    additionalModules.push(tokenSimulationModule.default || tokenSimulationModule);
+  }
 
   const modeler = new BpmnJS({
     container:       canvasEl,
@@ -602,9 +606,9 @@ function rebuildMenu() {
   
   avatarMenu = avatarDropdown(avatarStream, avatarOptions, currentTheme, buildDropdownOptions());
 
-  const controlsBar = row([
+  const controls = [
   // 1) avatar menu
-  avatarMenu,  
+  avatarMenu,
    
     
   // ─── Continuous Zoom In ────────────────────────────────────────────────────
@@ -651,26 +655,33 @@ function rebuildMenu() {
           a.click();
         });
       };
-      }, { outline: true, title: "Download as PNG" }),
-      // ─── Token simulation toggle ───────────────────────────────────────────
+      }, { outline: true, title: "Download as PNG" })
+  ];
+
+  if (tokenSimulationModule) {
+    controls.push(
       reactiveButton(
         new Stream("▶"),
         () => {
-          const simulation = modeler.get('tokenSimulation');
+          const simulation = modeler
+            .get('injector')
+            .get('tokenSimulation', false);
           if (simulation) simulation.toggle();
         },
         { outline: true, title: "Toggle Token Simulation" }
-      ),
-      saveBtn,
-      // ─── Continuous Zoom Outfinally theme selector
-      themedThemeSelector()
+      )
+    );
+  }
 
-  ], {
+  controls.push(saveBtn);
+  controls.push(themedThemeSelector());
+
+  const controlsBar = row(controls, {
     justify: 'flex-start',
     align:   'center',
     padding: '1rem',
     bg:      currentTheme.get().colors.surface,
-    wrap:    true, 
+    wrap:    true,
   });
 
   // keep background / border in sync


### PR DESCRIPTION
## Summary
- detect bpmn-js-token-simulation from the correct global and add it if present
- guard token simulation toggle button to avoid errors when module is missing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b7a16ab5c8328aec6deb377906ab5