### PR TITLE
fix: enable token simulation

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -672,7 +672,13 @@ function rebuildMenu() {
         const simulation = modeler
           .get('injector')
           .get('tokenSimulation', false);
-        if (simulation) simulation.toggle();
+        if (simulation) {
+          if (typeof simulation.toggleMode === 'function') {
+            simulation.toggleMode();
+          } else {
+            simulation.toggle();
+          }
+        }
       },
       { outline: true, title: "Toggle Token Simulation" }
     )


### PR DESCRIPTION
## Summary
- ensure token simulation button toggles module correctly for newer versions

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b8d5d71dc8328a371a0ba2b5cfb99