### PR TITLE
Add debug logging for button presses

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -227,6 +227,7 @@ document.body.appendChild(jsonFileInput);
 const saveBtn = reactiveButton(
   new Stream('💾'),
   async () => {
+    console.debug('Save button pressed');
     const { xml } = await modeler.saveXML({ format: true });
 
     // Use fallback/defaults if diagramDataStream is null

--- a/public/js/components/elements.js
+++ b/public/js/components/elements.js
@@ -328,8 +328,14 @@ function reactiveButton(labelStream, onClick, options = {}, themeStream = curren
   }
 
   button.addEventListener('click', () => {
+    console.debug('Button clicked', {
+      text: button.textContent,
+      disabled: button.disabled
+    });
     if (!button.disabled) {
       onClick();
+    } else {
+      console.debug('Click ignored: button disabled');
     }
   });
 


### PR DESCRIPTION
## Summary
- Log button click events within the reusable reactive button component
- Log when the save button handler is triggered

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689b8ea38c80832895fb7cd39374f107