### PR TITLE
Hide token simulation button if plugin missing

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -666,25 +666,26 @@ function rebuildMenu() {
       }, { outline: true, title: "Download as PNG" })
   ];
 
-  controls.push(
-    reactiveButton(
-      new Stream("▶"),
-      () => {
-        const simulation = modeler
-          .get('injector')
-          .get('tokenSimulation', false);
-          console.log('676', simulation);
-        if (simulation) {
+  if (tokenSimulationModule) {
+    controls.push(
+      reactiveButton(
+        new Stream("▶"),
+        () => {
+          const simulation = modeler.get('tokenSimulation', false);
+          if (!simulation) {
+            console.warn('Token simulation service not available');
+            return;
+          }
           if (typeof simulation.toggleMode === 'function') {
             simulation.toggleMode();
           } else {
             simulation.toggle();
           }
-        }
-      },
-      { outline: true, title: "Toggle Token Simulation" }
-    )
-  );
+        },
+        { outline: true, title: "Toggle Token Simulation" }
+      )
+    );
+  }
 
   controls.push(saveBtn);
   controls.push(themedThemeSelector());


### PR DESCRIPTION
## Summary
- show token simulation control only when plugin is loaded
- warn when token simulation service is unavailable

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b91190d848328824118cdc5606df9