### PR TITLE
Load token simulation plugin from CDN

### DIFF
--- a/public/js/vendor/bpmn-js-token-simulation.umd.js
+++ b/public/js/vendor/bpmn-js-token-simulation.umd.js
@@ -1,4 +1,24 @@
-(function(global){
-  // Stub implementation for BpmnJSTokenSimulation.
-  global.BpmnJSTokenSimulation = global.BpmnJSTokenSimulation || {};
+(function (global) {
+  /**
+   * Load the real bpmn-js-token-simulation UMD bundle from a CDN.
+   * The original repository does not ship a pre-built bundle with the npm
+   * package, therefore we dynamically fetch the official UMD build and expose
+   * its global so that `app.js` can resolve `tokenSimulationModule`.
+   */
+  var script = document.createElement('script');
+  script.src =
+    'https://unpkg.com/bpmn-js-token-simulation@0.31.0/dist/bpmn-js-token-simulation.umd.js';
+
+  script.onload = function () {
+    // Align with the various globals that may be exposed by the UMD bundle
+    global.BpmnJSTokenSimulation =
+      global.BpmnJSTokenSimulation ||
+      global.BpmnJsTokenSimulation ||
+      global.TokenSimulationModule ||
+      global.TokenSimulation ||
+      global['bpmn-js-token-simulation'] ||
+      global.tokenSimulationModule;
+  };
+
+  document.head.appendChild(script);
 })(window);


### PR DESCRIPTION
## Summary
- replace stub token-simulation script with loader that fetches official UMD build

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689bb8bde79c8328b6b9c7c568beabb6