### PR TITLE
feat: wait for token simulation bundle

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -38,7 +38,7 @@ const defaultXml = `<?xml version="1.0" encoding="UTF-8"?>
 // === Initial BPMN XML template ===
 const diagramXMLStream = new Stream(defaultXml);
 
-document.addEventListener('DOMContentLoaded', () => {  
+document.addEventListener('DOMContentLoaded', async () => {
 
 const avatarStream = new Stream('flow.png');
 let currentDiagramId = null;
@@ -67,15 +67,6 @@ Object.assign(document.body.style, {
   const layoutProcess    = window.bpmnAutoLayout?.layoutProcess;
   const NavigatorModule  = window.NavigatorModule;
 
-  // try the known globals exposed by the UMD bundle
-  const tokenSimulationModule =
-    window.BpmnJSTokenSimulation ||
-    window.BpmnJsTokenSimulation ||
-    window.TokenSimulationModule ||
-    window.TokenSimulation ||
-    window['bpmn-js-token-simulation'] ||
-    window.tokenSimulationModule;
-
   // ─── build canvas + xml-editor elements ────────────────────────────────────
   // REPLACE with this:
   const canvasEl = document.getElementById('canvas');
@@ -101,6 +92,19 @@ Object.assign(document.body.style, {
 
   const additionalModules = [];
   if (navModule) additionalModules.push(navModule);
+
+  if (window.BpmnJSTokenSimulationReady) {
+    await window.BpmnJSTokenSimulationReady;
+  }
+
+  const tokenSimulationModule =
+    window.BpmnJSTokenSimulation ||
+    window.BpmnJsTokenSimulation ||
+    window.TokenSimulationModule ||
+    window.TokenSimulation ||
+    window['bpmn-js-token-simulation'] ||
+    window.tokenSimulationModule;
+
   if (tokenSimulationModule) {
     // UMD build may expose the module on `default`
     additionalModules.push(tokenSimulationModule.default || tokenSimulationModule);

--- a/public/js/vendor/bpmn-js-token-simulation.umd.js
+++ b/public/js/vendor/bpmn-js-token-simulation.umd.js
@@ -1,10 +1,16 @@
+/**
+ * Tiny helper that loads the token simulation bundle from a CDN and exposes a
+ * promise that resolves once the script finished loading.  Consumers may await
+ * `window.BpmnJSTokenSimulationReady` to ensure the plugin is available.
+ */
 (function (global) {
-  /**
-   * Load the real bpmn-js-token-simulation UMD bundle from a CDN.
-   * The original repository does not ship a pre-built bundle with the npm
-   * package, therefore we dynamically fetch the official UMD build and expose
-   * its global so that `app.js` can resolve `tokenSimulationModule`.
-   */
+  var resolveReady;
+
+  // Expose a promise for consumers to await
+  global.BpmnJSTokenSimulationReady = new Promise(function (resolve) {
+    resolveReady = resolve;
+  });
+
   var script = document.createElement('script');
   script.src =
     'https://unpkg.com/bpmn-js-token-simulation@0.31.0/dist/bpmn-js-token-simulation.umd.js';
@@ -18,6 +24,14 @@
       global.TokenSimulation ||
       global['bpmn-js-token-simulation'] ||
       global.tokenSimulationModule;
+
+    resolveReady(global.BpmnJSTokenSimulation);
+  };
+
+  // Resolve the promise even if loading fails so callers can continue
+  script.onerror = function (err) {
+    console.error('Failed to load bpmn-js-token-simulation bundle', err);
+    resolveReady();
   };
 
   document.head.appendChild(script);


### PR DESCRIPTION
## Summary
- expose a `BpmnJSTokenSimulationReady` promise for the CDN-loaded token simulation module
- await the token simulation bundle before constructing `BpmnJS`
- add the toggle token simulation button only after the module is available

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ca2ba08c88328aefe506b766e4d97