### PR TITLE
fix: load token simulation from maintained package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "bpmn-auto-layout": "^1.0.1",
     "bpmn-js-properties-panel": "^5.37.0",
-    "bpmn-js-token-simulation": "^0.31.0",
+    "@bpmn-io/token-simulation": "^0.24.0",
     "bpmn-moddle": "^9.0.2",
     "camunda-bpmn-moddle": "^7.0.1",
     "diagram-js-minimap": "^5.2.0"

--- a/public/index.html
+++ b/public/index.html
@@ -14,8 +14,8 @@
   <link rel="stylesheet"
         href="https://unpkg.com/bpmn-js@18.6.2/dist/assets/bpmn-font/css/bpmn.css" />
 
-  <!-- Token simulation plugin CSS (local) -->
-  <link rel="stylesheet" href="js/vendor/bpmn-js-token-simulation.css" />
+  <!-- Token simulation plugin CSS -->
+  <link rel="stylesheet" href="https://unpkg.com/@bpmn-io/token-simulation@0.24.0/dist/assets/token-simulation.css" />
 
   <style>
   html, body, #canvas, #palette {

--- a/public/js/vendor/bpmn-js-token-simulation.umd.js
+++ b/public/js/vendor/bpmn-js-token-simulation.umd.js
@@ -13,7 +13,7 @@
 
   var script = document.createElement('script');
   script.src =
-    'https://unpkg.com/bpmn-js-token-simulation@0.31.0/dist/bpmn-js-token-simulation.umd.js';
+    'https://unpkg.com/@bpmn-io/token-simulation@0.24.0/dist/index.umd.js';
 
   script.onload = function () {
     // Align with the various globals that may be exposed by the UMD bundle


### PR DESCRIPTION
## Summary
- switch to `@bpmn-io/token-simulation` and load its bundle
- reference updated token-simulation styles from CDN

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cef6c37708328b5f0241bb5f6f949