### PR TITLE
feat: add token simulation bundle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,10 @@
   <link rel="stylesheet"
         href="https://unpkg.com/bpmn-js@18.6.2/dist/assets/bpmn-font/css/bpmn.css" />
 
+  <!-- 2.5) Token simulation styles -->
+  <link rel="stylesheet"
+        href="https://unpkg.com/bpmn-js-token-simulation@0.24.0/dist/assets/bpmn-js-token-simulation.css" />
+
 
   <style>
   html, body, #canvas, #palette {
@@ -56,6 +60,8 @@
   <!-- 4) auto-layout + navigator -->
   <script src="https://unpkg.com/bpmn-auto-layout@0.4.0/dist/bpmn-auto-layout.umd.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@bpmn-io/navigator@1.0.0/dist/bpmn-navigator.umd.js"></script>
+  <!-- 4.5) token simulation -->
+  <script src="https://unpkg.com/bpmn-js-token-simulation@0.24.0/dist/bpmn-js-token-simulation.umd.js"></script>
   <!-- Firebase Core + Auth (10.12.0) -->
   <!-- Firebase App (always required) -->
   <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-app-compat.js"></script>


### PR DESCRIPTION
## Summary
- include Token Simulation CSS and UMD script in index.html so tokenSimulationModule can be detected

## Testing
- `npm test` *(fails: Missing script)*
- `curl -H "User-Agent: Mozilla/5.0" https://unpkg.com/bpmn-js-token-simulation@0.24.0/dist/bpmn-js-token-simulation.umd.js | head` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689d036d6d1083289e443509d89f5528