### PR TITLE
Warn when token simulation module missing

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -97,17 +97,26 @@ Object.assign(document.body.style, {
     await window.BpmnJSTokenSimulationReady;
   }
 
-  const tokenSimulationModule =
-    window.BpmnJSTokenSimulation ||
-    window.BpmnJsTokenSimulation ||
-    window.TokenSimulationModule ||
-    window.TokenSimulation ||
-    window['bpmn-js-token-simulation'] ||
-    window.tokenSimulationModule;
+  const tokenSimulationGlobals = [
+    'BpmnJSTokenSimulation',
+    'BpmnJsTokenSimulation',
+    'TokenSimulationModule',
+    'TokenSimulation',
+    'bpmn-js-token-simulation',
+    'tokenSimulationModule'
+  ];
+
+  const tokenSimulationGlobal = tokenSimulationGlobals.find(name => window[name]);
+  const tokenSimulationModule = tokenSimulationGlobal && window[tokenSimulationGlobal];
 
   if (tokenSimulationModule) {
     // UMD build may expose the module on `default`
     additionalModules.push(tokenSimulationModule.default || tokenSimulationModule);
+  } else {
+    console.warn(
+      'bpmn-js-token-simulation module not found. Expected one of globals:',
+      tokenSimulationGlobals.join(', ')
+    );
   }
 
   const modeler = new BpmnJS({


### PR DESCRIPTION
## Summary
- Look up token-simulation plugin via known global names and log a warning if none found.

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Missing script "build")

------
https://chatgpt.com/codex/tasks/task_e_689d06027ce48328927bda1305f836bb