### PR TITLE
Add timer-based stream helpers

### DIFF
--- a/public/js/core/stream.js
+++ b/public/js/core/stream.js
@@ -92,6 +92,37 @@ function fieldStream(sourceStream, fieldName) {
   return derived;
 }
 
+// === Helper: interval stream ===
+/**
+ * Emits the result of `fn` every `ms` milliseconds.
+ *
+ * Usage:
+ * const [tickStream, stop] = intervalStream(1000, () => Date.now());
+ * const unsub = tickStream.subscribe(console.log);
+ * // later: stop(); unsub();
+ */
+function intervalStream(ms, fn) {
+  const stream = new Stream();
+  const id = setInterval(() => stream.set(fn()), ms);
+  const cleanup = () => clearInterval(id);
+  return [stream, cleanup];
+}
+
+// === Helper: timeout stream ===
+/**
+ * Emits `value` once after `ms` milliseconds.
+ *
+ * Usage:
+ * const [doneStream, cancel] = timeoutStream(5000, 'done');
+ * doneStream.subscribe(console.log);
+ * // later: cancel();
+ */
+function timeoutStream(ms, value) {
+  const stream = new Stream();
+  const id = setTimeout(() => stream.set(value), ms);
+  const cleanup = () => clearTimeout(id);
+  return [stream, cleanup];
+}
 
 function observeDOMRemoval(el, ...cleanups) {
   const observer = new MutationObserver(() => {


### PR DESCRIPTION
## Summary
- add `intervalStream` utility emitting values at set intervals with cleanup
- add `timeoutStream` utility emitting once after a delay with cleanup
- document example usage for new helpers

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ddca508908328a9d185feea343020