### PR TITLE
fix: guard grid keys and remove debug log

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -350,11 +350,10 @@ isDirty.subscribe(d => {
 
 // when showSaveButton changes, enable/disable the button automatically:
 showSaveButton.subscribe(d => {
-  console.log("195", d);
   if (d) {
-    saveBtn.visible = true;  
+    saveBtn.visible = true;
   } else {
-    saveBtn.visible = false;  
+    saveBtn.visible = false;
   }
 });
 

--- a/public/js/components/elements.js
+++ b/public/js/components/elements.js
@@ -707,7 +707,8 @@ function gridView(dataStream, options = {}, themeStream = currentTheme) {
   function renderGrid(data = [], theme = {}) {
     const colors = theme.colors || {};
     const fonts = theme.fonts || {};
-    const keys = data.length > 0 ? Object.keys(data[0]) : [];
+    const firstRow = Array.isArray(data) && data.length > 0 ? data[0] : {};
+    const keys = Object.keys(firstRow);
 
     table.innerHTML = '';
 


### PR DESCRIPTION
## Summary
- remove leftover debug logging when toggling save button
- avoid Object.keys crash by guarding grid data

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689de1b6d618832883017b8d395bd877