### PR TITLE
Add robust H1 heading checker

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -82,7 +82,8 @@
   <script src="js/firebase.js"></script>
   <script src="js/login.js"></script>
   <script src="js/app.js"></script>
+  <script src="js/h1-check.js"></script>
   <!-- 7) more to come -->
-   
+
 </body>
 </html>

--- a/public/js/h1-check.js
+++ b/public/js/h1-check.js
@@ -1,0 +1,24 @@
+/**
+ * Simple utility to log all H1 elements on the page.
+ * Ensures Object.keys is only called with a valid object.
+ */
+(function () {
+  function logHeadings(obj) {
+    if (!obj || typeof obj !== 'object') {
+      console.warn('h1-check: expected an object, received', obj);
+      return;
+    }
+
+    Object.keys(obj).forEach(function (key) {
+      console.log(key, obj[key]);
+    });
+  }
+
+  const h1Nodes = document.querySelectorAll('h1');
+  const headings = Array.from(h1Nodes).reduce(function (acc, node, index) {
+    acc[index] = node.textContent;
+    return acc;
+  }, {});
+
+  logHeadings(headings);
+})();


### PR DESCRIPTION
## Summary
- add a dedicated h1-check utility that safely logs H1 elements without Object.keys errors
- include the new h1-check script in the main index.html

## Testing
- `npm test` *(fails: Missing script "test"))*

------
https://chatgpt.com/codex/tasks/task_e_689f389e7228832886e4c5d8ba09db31