### PR TITLE
feat: highlight active BPMN elements

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -40,6 +40,18 @@
     max-width: 100vw;
     box-sizing: border-box;
   }
+
+  /* highlight currently active BPMN element during simulation */
+  .djs-element.active .djs-visual > :nth-child(1) {
+    stroke: #ff5722;
+    stroke-width: 4px;
+  }
+
+  /* highlight active sequence flows */
+  .djs-connection.active .djs-visual > :nth-child(1) {
+    stroke: #ff5722;
+    stroke-width: 4px;
+  }
   </style>
 
 </head>


### PR DESCRIPTION
## Summary
- highlight currently active BPMN elements and sequence flows during simulation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f6dde0b1883288a6e8c68be7d7b1f