### PR TITLE
Display simulation control logs

### DIFF
--- a/public/js/components/elements.js
+++ b/public/js/components/elements.js
@@ -328,14 +328,14 @@ function reactiveButton(labelStream, onClick, options = {}, themeStream = curren
   }
 
   button.addEventListener('click', () => {
-    console.debug('Button clicked', {
+    console.log('Button clicked', {
       text: button.textContent,
       disabled: button.disabled
     });
     if (!button.disabled) {
       onClick();
     } else {
-      console.debug('Click ignored: button disabled');
+      console.log('Click ignored: button disabled');
     }
   });
 


### PR DESCRIPTION
## Summary
- ensure reactive buttons log to the console using `console.log`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f758f36f8832885095b80c9867189