### PR TITLE
fix: warn when diagram lacks StartEvent for simulation

### DIFF
--- a/public/js/core/simulation.js
+++ b/public/js/core/simulation.js
@@ -33,7 +33,14 @@ function createSimulation(services, opts = {}) {
   });
 
   function getStart() {
-    return elementRegistry.filter(e => e.type === 'bpmn:StartEvent')[0] || null;
+    const all = elementRegistry.filter
+      ? elementRegistry.filter(e => e.type === 'bpmn:StartEvent' || e.businessObject?.$type === 'bpmn:StartEvent')
+      : [];
+    const start = all[0] || null;
+    if (!start) {
+      console.warn('No StartEvent found in diagram');
+    }
+    return start;
   }
 
   function schedule() {


### PR DESCRIPTION
## Summary
- warn when diagram has no StartEvent when starting simulation
- search start events via type or businessObject type

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f7af6b10483288bb0b7cbf88075d5