### PR TITLE
Embed active-element highlight styling

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -747,6 +747,13 @@ currentTheme.subscribe(theme => {
       stroke: ${bpmn.selected.stroke} !important;
       stroke-width: ${bpmn.selected.strokeWidth}px !important;
     }
+
+    /* ── simulation active token highlight ─────────────────────────────── */
+    .djs-element.active .djs-visual > :nth-child(1),
+    .djs-connection.active .djs-visual > path {
+      stroke: orange !important;
+      stroke-width: 4px !important;
+    }
   `;
 });
 


### PR DESCRIPTION
## Summary
- Inject style rules into app setup so active BPMN shapes/flows receive an orange stroke

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f8c4f49b08328a4027702b0f9e059