### PR TITLE
Remove default StartEvent from new diagrams

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -28,7 +28,6 @@ const defaultXml = `<?xml version="1.0" encoding="UTF-8"?>
                     xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
                     id="Definitions_1">
     <bpmn:process id="Process_1" isExecutable="true">
-      <bpmn:startEvent id="StartEvent_1"/>
     </bpmn:process>
     <bpmndi:BPMNDiagram id="BPMNDiagram_1">
       <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1"/>

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -549,8 +549,9 @@ function handleAttachmentSelection(attachmentId, versionIndex) {
         return;
       }
 
-      // Example: Add attachment to a specific diagram element (replace `elementId` with actual id)
-      const elementId = 'StartEvent_1'; // Replace with actual element ID
+      // Example: Add attachment to a specific diagram element
+      // Replace `elementId` with the ID of the element you want to target
+      const elementId = 'YOUR_ELEMENT_ID';
       const updatedElementMetadata = {
         ...currentDiagramData[elementId],
         attachments: [


### PR DESCRIPTION
## Summary
- Remove hardcoded StartEvent from initial BPMN XML template
- Generalize placeholder element ID in attachment logic

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node -e "const fs=require('fs'); const app=fs.readFileSync('public/js/app.js','utf8'); console.log(/<bpmn:startEvent/.test(app));"`

------
https://chatgpt.com/codex/tasks/task_e_689fbb7c21fc83288f4c4a439153f271