### PR TITLE
feat: add flow selection modal

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -109,7 +109,6 @@ Object.assign(document.body.style, {
         const { xml } = await modeler.saveXML({ format: true });
         diagramXMLStream.set(xml);
         isDirty.set(true);
-        console.log("72");
       } catch (err) {
         console.error('failed to save current XML:', err);
       }
@@ -128,15 +127,12 @@ Object.assign(document.body.style, {
   // Prompt user to choose path at gateways
   simulation.pathsStream.subscribe(flows => {
     if (!flows || !flows.length) return;
-    const message = 'Select next element:\n' + flows
-      .map((f, i) => `${i + 1}. ${f.target?.businessObject?.name || f.target?.id}`)
-      .join('\n');
-    const input = window.prompt(message);
-    const index = parseInt(input, 10) - 1;
-    const chosen = flows[index];
-    if (chosen) {
-      simulation.step(chosen.id);
-    }
+    // Use the flow selection modal to pick a path
+    window.openFlowSelectionModal(flows, currentTheme).subscribe(chosen => {
+      if (chosen) {
+        simulation.step(chosen.id);
+      }
+    });
   });
 
   // ─── theme (page background) ────────────────────────────────────────────────

--- a/public/js/components/elements.js
+++ b/public/js/components/elements.js
@@ -427,6 +427,98 @@ function headerContainer(titleStream) {
 }
 
 
+function openFlowSelectionModal(flows, themeStream = currentTheme) {
+  const pickStream = new Stream(null);
+
+  // Overlay
+  const modal = document.createElement('div');
+  Object.assign(modal.style, {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    width: '100vw',
+    height: '100vh',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    zIndex: 9999
+  });
+
+  // Content box
+  const content = document.createElement('div');
+  Object.assign(content.style, {
+    padding: '1.5rem',
+    borderRadius: '8px',
+    boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+    minWidth: '300px',
+    maxHeight: '80vh',
+    overflowY: 'auto',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem'
+  });
+
+  const title = document.createElement('h3');
+  title.textContent = 'Select Next Node';
+  content.appendChild(title);
+
+  const list = document.createElement('div');
+  list.style.display = 'flex';
+  list.style.flexDirection = 'column';
+  list.style.gap = '0.5rem';
+  content.appendChild(list);
+
+  flows.forEach(flow => {
+    const item = document.createElement('div');
+    item.textContent = flow.target?.businessObject?.name || flow.target?.id;
+    Object.assign(item.style, {
+      padding: '0.5rem 1rem',
+      borderRadius: '4px',
+      cursor: 'pointer'
+    });
+
+    item.addEventListener('click', () => {
+      pickStream.set(flow);
+      modal.remove();
+    });
+
+    list.appendChild(item);
+  });
+
+  modal.appendChild(content);
+  document.body.appendChild(modal);
+
+  const applyStyles = theme => {
+    const { colors, fonts } = theme;
+    content.style.backgroundColor = colors.surface || '#fff';
+    content.style.color = colors.foreground || '#000';
+    content.style.fontFamily = fonts.base || 'sans-serif';
+    Array.from(list.children).forEach(child => {
+      child.style.backgroundColor = colors.primary || '#f9f9f9';
+      child.style.border = `1px solid ${colors.border || '#ccc'}`;
+      child.onmouseover = () => child.style.backgroundColor = colors.accent + '55';
+      child.onmouseout = () => child.style.backgroundColor = colors.primary || '#f9f9f9';
+    });
+  };
+
+  themeStream.subscribe(applyStyles);
+  applyStyles(themeStream.get());
+
+  modal.addEventListener('click', e => {
+    if (e.target === modal) {
+      pickStream.set(null);
+      modal.remove();
+    }
+  });
+
+  return pickStream;
+}
+
+// Expose modal helper globally so other scripts can invoke it
+window.openFlowSelectionModal = openFlowSelectionModal;
+
+
 function groupedDocumentGrid(documentsStream, expandedStream, themeStream = currentTheme, keys = ['title', 'status', 'meta', 'filename']) {
   const wrapper = document.createElement('div');
   wrapper.style.overflowX = 'auto';


### PR DESCRIPTION
## Summary
- add themed flow selection modal with clickable nodes
- replace prompt with flow selection modal in simulation
- expose flow selection modal on `window` and integrate into simulation

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fc154c9f083288f4a9cde25f2790c