### PR TITLE
Expose flow selection modal globally

### DIFF
--- a/public/js/components/elements.js
+++ b/public/js/components/elements.js
@@ -514,6 +514,8 @@ function openFlowSelectionModal(flows, themeStream = currentTheme) {
 
   return pickStream;
 }
+// Expose helper globally for external usage
+window.openFlowSelectionModal = openFlowSelectionModal;
 
 
 


### PR DESCRIPTION
## Summary
- make flow selection modal globally accessible

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fc5bb97848328a2c69e8486de3d1a