### PR TITLE
Fix gateway path selection modal reference

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -127,8 +127,9 @@ Object.assign(document.body.style, {
   // Prompt user to choose path at gateways
   simulation.pathsStream.subscribe(flows => {
     if (!flows || !flows.length) return;
-
-    openFlowSelectionModal(flows, currentTheme).subscribe(chosen => {
+    // Access modal helper via `window` to avoid ReferenceError when used
+    // within modules or strict scopes
+    window.openFlowSelectionModal(flows, currentTheme).subscribe(chosen => {
       if (chosen) {
         simulation.step(chosen.id);
       }


### PR DESCRIPTION
## Summary
- avoid ReferenceError by accessing `openFlowSelectionModal` via `window`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689fc6b6b1848328a4895414ddc60145