### PR TITLE
Reset simulation state after completion

### DIFF
--- a/public/js/core/simulation.js
+++ b/public/js/core/simulation.js
@@ -67,7 +67,11 @@ function createSimulation(services, opts = {}) {
 
     const flow = flowId ? elementRegistry.get(flowId) : outgoing[0];
     if (!flow) {
-      console.log('No outgoing flow, simulation paused at', current.id);
+      console.log('No outgoing flow, simulation finished at', current.id);
+      // clear token and reset state so simulation can start over cleanly
+      tokenStream.set(null);
+      pathsStream.set(null);
+      current = null;
       pause();
       return;
     }


### PR DESCRIPTION
## Summary
- clear token and reset state when simulation reaches an end so it can start again

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689fc8c894f483288259861787f9f7a9