### PR TITLE
Add viewport meta tag for responsive layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Flow Control Center</title>
 
   <!-- 1) Core BPMN + diagram-js CSS -->


### PR DESCRIPTION
## Summary
- Include viewport meta tag in `public/index.html` to ensure responsive layout on various devices

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a49349dad083288cd4b5e301a2e95b