### PR TITLE
Make canvas height responsive

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -71,7 +71,9 @@ Object.assign(document.body.style, {
   const canvasEl = document.getElementById('canvas');
   Object.assign(canvasEl.style, {
     flex:      '1 1 auto',
-    minHeight: '600px',
+    // Use a viewport based minimum height so the canvas scales with screen size
+    // rather than being locked to a fixed pixel value.
+    minHeight: '60vh',
     width:     '100%',
     border:    `1px solid ${currentTheme.get().colors.border}`
   });


### PR DESCRIPTION
## Summary
- use viewport-based `minHeight` to let BPMN canvas scale with screen size

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx -p puppeteer@21 node` *(fails: 403 Forbidden fetching puppeteer package)*
- `node -e` calculated expected minHeight for desktop and mobile

------
https://chatgpt.com/codex/tasks/task_e_68a4960e4ba08328b8a96bb8c3e9bc23