### PR TITLE
Use CSS for responsive properties sidebar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -42,6 +42,41 @@
     box-sizing: border-box;
   }
 
+  /* properties sidebar */
+  .props-sidebar {
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 100%;
+    background: #fff;
+    box-shadow: -2px 0 6px rgba(0,0,0,0.2);
+    padding: 1rem;
+    overflow-y: auto;
+    overflow-x: hidden;
+    display: flex;
+    flex-direction: column;
+    transition: transform 0.3s;
+    z-index: 1000;
+    width: 300px;
+    transform: translateX(100%);
+  }
+
+  .props-sidebar.open {
+    transform: translateX(0);
+  }
+
+  @media (max-width: 768px) {
+    .props-sidebar {
+      width: 80vw;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .props-sidebar {
+      width: 100vw;
+    }
+  }
+
   /* highlight currently active BPMN element during simulation */
   .djs-element.active .djs-visual > :nth-child(1) {
     stroke: #ff5722;

--- a/public/js/components/showProperties.js
+++ b/public/js/components/showProperties.js
@@ -1,22 +1,7 @@
 // 1) Create the sidebar container (hidden by default)
-  const propsSidebar = document.createElement('div');
-Object.assign(propsSidebar.style, {
-  position:    'absolute',
-  top:         '0',
-  right:       '-400px',       // slide it offscreen initially
-  width:       '300px',
-  height:      '100%',
-  background:  '#fff',
-  boxShadow:   '-2px 0 6px rgba(0,0,0,0.2)',
-  padding:     '1rem',
-  overflowY:   'auto',
-  overflowX:   'hidden',       // prevent horizontal scroll if not needed
-  display:     'flex',
-  flexDirection: 'column',
-  transition:  'right 0.3s',
-  zIndex: '1000',
-});
-  document.body.appendChild(propsSidebar);
+const propsSidebar = document.createElement('div');
+propsSidebar.classList.add('props-sidebar');
+document.body.appendChild(propsSidebar);
 
 
 const BPMN_PROPERTY_MAP = {
@@ -618,7 +603,7 @@ function showProperties(element, modeling, moddle, currentUser) {
 
 
   propsSidebar.append(form);
-  propsSidebar.style.right = '0';
+  propsSidebar.classList.add('open');
 
   const unsub = currentTheme.subscribe(theme => {
     propsSidebar.style.backgroundColor = theme.colors.surface;
@@ -664,7 +649,7 @@ function getOrCreateExtEl(bo, moddle) {
       
   // hide helper cleans up subscription
   function hideSidebar() {
-    propsSidebar.style.right = '-400px';
+    propsSidebar.classList.remove('open');
     if (propsSidebar._unsubTheme) {
       propsSidebar._unsubTheme();
       delete propsSidebar._unsubTheme;      


### PR DESCRIPTION
## Summary
- Move properties sidebar layout from inline styles to a reusable `.props-sidebar` CSS class and toggle visibility with an `open` class.
- Add responsive media queries so the sidebar scales to `80vw` on tablets and `100vw` on very small screens.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a49dbb1b3c8328a345895db4c9409f