### PR TITLE
feat: add mobile-friendly palette toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -88,12 +88,45 @@
     stroke: #ff5722;
     stroke-width: 4px;
   }
+
+  /* mobile palette toggle */
+  #toggle-palette {
+    display: none;
+  }
+
+  @media (max-width: 768px) {
+    #palette {
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      width: 70%;
+      max-width: 300px;
+      overflow-y: auto;
+      background: #fff;
+      z-index: 1000;
+    }
+
+    #palette.open {
+      display: block;
+    }
+
+    #toggle-palette {
+      display: block;
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      z-index: 1100;
+    }
+  }
   </style>
 
 </head>
 
 <body>
   <!-- Jazira toolbar will be injected here -->
+  <button id="toggle-palette" aria-label="Toggle palette">Tools</button>
   <!-- Palette + canvas wrapper -->
   <div id="diagram-wrapper" style="display:flex; flex:1; overflow:hidden">
     <div id="palette"></div>
@@ -131,6 +164,7 @@
   <script src="js/login.js"></script>
   <script src="js/app.js"></script>
   <script src="js/h1-check.js"></script>
+  <script src="js/palette-toggle.js"></script>
   <!-- 7) more to come -->
 
 </body>

--- a/public/js/palette-toggle.js
+++ b/public/js/palette-toggle.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const palette = document.getElementById('palette');
+  const btn = document.getElementById('toggle-palette');
+  if (palette && btn) {
+    btn.addEventListener('click', function() {
+      palette.classList.toggle('open');
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- hide BPMN palette on narrow screens
- add button and script to toggle palette visibility on mobile

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a4a70634fc8328a74c7289ad6b8e73