### PR TITLE
Highlight BPMN nodes by add-on type

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,0 +1,11 @@
+.djs-element.bpmn-addOn-highlight .djs-visual > :nth-child(1) {
+  stroke: #ff9800;
+  stroke-width: 4px;
+  fill: rgba(255, 152, 0, 0.3);
+  filter: drop-shadow(0 0 6px #ff9800);
+}
+
+.djs-connection.bpmn-addOn-highlight .djs-visual > :nth-child(1) {
+  stroke: #ff9800;
+  stroke-width: 4px;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -15,6 +15,8 @@
   <link rel="stylesheet"
         href="https://unpkg.com/bpmn-js@18.6.2/dist/assets/bpmn-font/css/bpmn.css" />
 
+  <link rel="stylesheet" href="css/app.css" />
+
 
 
   <style>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -200,6 +200,31 @@ Object.assign(document.body.style, {
     };
   }
 
+  // Highlight nodes matching selected type/subtype
+  const highlightedNodes = new Set();
+
+  function updateHighlightedNodes() {
+    // remove previous markers
+    highlightedNodes.forEach(id => canvas.removeMarker(id, 'bpmn-addOn-highlight'));
+    highlightedNodes.clear();
+
+    const type = selectedType.get();
+    if (!type || !window.addOnStore) return;
+
+    const subtype = selectedSubtype.get();
+    const nodeIds = subtype
+      ? addOnStore.findNodesBySubtype(type, subtype)
+      : addOnStore.findNodesByType(type);
+
+    nodeIds.forEach(id => {
+      canvas.addMarker(id, 'bpmn-addOn-highlight');
+      highlightedNodes.add(id);
+    });
+  }
+
+  selectedType.subscribe(updateHighlightedNodes);
+  selectedSubtype.subscribe(updateHighlightedNodes);
+
   // --- Add-on store helpers -------------------------------------------------
   function syncAddOnStoreFromElements() {
     if (!window.addOnStore) return;


### PR DESCRIPTION
## Summary
- highlight diagram elements when filtering by add-on type/subtype
- add CSS class and stylesheet for highlighted elements
- include custom stylesheet in index

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4cf8c31888328a5acbf6c05800adc