### PR TITLE
feat: add reactive add-on legend

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -162,6 +162,7 @@
   <script src="js/components/layout.js"></script>
   <script src="js/components/showProperties.js"></script>
   <script src="js/components/addOnFilter.js"></script>
+  <script src="js/components/addOnLegend.js"></script>
   <!-- 6) Your application code -->
   <script src="js/firebase.js"></script>
   <script src="js/login.js"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -200,6 +200,11 @@ Object.assign(document.body.style, {
     };
   }
 
+  if (window.addOnLegend) {
+    const legendEl = addOnLegend.createAddOnLegend(typeIcons, currentTheme);
+    document.body.appendChild(legendEl);
+  }
+
   // Highlight nodes matching selected type/subtype
   const highlightedNodes = new Set();
 

--- a/public/js/components/addOnLegend.js
+++ b/public/js/components/addOnLegend.js
@@ -1,0 +1,82 @@
+(function(global){
+  function createAddOnLegend(typeIcons = {}, themeStream = currentTheme){
+    const container = document.createElement('div');
+    Object.assign(container.style, {
+      position: 'absolute',
+      top: '1rem',
+      right: '1rem',
+      padding: '0.5rem 0.75rem',
+      borderRadius: '4px',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '0.25rem',
+      zIndex: '1000',
+      fontSize: '14px'
+    });
+
+    const countEls = {};
+    Object.entries(typeIcons).forEach(([type, icon]) => {
+      const row = document.createElement('div');
+      Object.assign(row.style, {
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.25rem'
+      });
+      const iconSpan = document.createElement('span');
+      iconSpan.textContent = icon;
+      const countSpan = document.createElement('span');
+      countSpan.textContent = '0';
+      row.appendChild(iconSpan);
+      row.appendChild(countSpan);
+      container.appendChild(row);
+      countEls[type] = countSpan;
+    });
+
+    function computeCounts(){
+      const counts = {};
+      if(!global.addOnStore || !addOnStore.getAllAddOns) return counts;
+      const all = addOnStore.getAllAddOns();
+      Object.values(all).forEach(addOns => {
+        const seen = new Set();
+        (addOns || []).forEach(a => {
+          if(a && a.type) seen.add(a.type);
+        });
+        seen.forEach(t => {
+          counts[t] = (counts[t] || 0) + 1;
+        });
+      });
+      return counts;
+    }
+
+    const countsStream = new Stream(computeCounts());
+    countsStream.subscribe(counts => {
+      Object.keys(typeIcons).forEach(type => {
+        countEls[type].textContent = counts[type] || 0;
+      });
+    });
+
+    if(global.addOnStore){
+      const originalSet = addOnStore.setAddOns;
+      addOnStore.setAddOns = function(nodeId, addOns){
+        originalSet(nodeId, addOns);
+        countsStream.set(computeCounts());
+      };
+      const originalClear = addOnStore.clear;
+      addOnStore.clear = function(){
+        originalClear();
+        countsStream.set(computeCounts());
+      };
+    }
+
+    themeStream.subscribe(theme => {
+      container.style.background = theme.colors.surface;
+      container.style.color = theme.colors.foreground;
+      container.style.border = `1px solid ${theme.colors.border}`;
+      container.style.fontFamily = theme.fonts.base || 'sans-serif';
+    });
+
+    return container;
+  }
+
+  global.addOnLegend = { createAddOnLegend };
+})(window);


### PR DESCRIPTION
## Summary
- add legend component showing add-on type icons with reactive counts
- mount legend near the canvas and style via current theme

## Testing
- `npm test` *(fails: Missing script 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68a4d13f13dc832896b2f5c87ae0b9ed