### PR TITLE
Add toggle for on-demand add-on filter panel

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -52,12 +52,27 @@ const overlay = createDiagramOverlay(
   versionStream,
   currentTheme
 );
-
-
   const { createAddOnFilterPanel, selectedType, selectedSubtype } = window.addOnFilter;
-  const addOnFilterPanelEl = createAddOnFilterPanel(currentTheme);
-  document.body.appendChild(addOnFilterPanelEl);
+  let addOnFilterPanelEl = null;
 
+  const filterToggleBtn = document.createElement('button');
+  filterToggleBtn.textContent = 'Filters';
+  Object.assign(filterToggleBtn.style, {
+    position: 'fixed',
+    top: '10px',
+    right: '10px',
+    zIndex: '1001'
+  });
+  document.body.appendChild(filterToggleBtn);
+
+  filterToggleBtn.addEventListener('click', () => {
+    if (!addOnFilterPanelEl) {
+      addOnFilterPanelEl = createAddOnFilterPanel(currentTheme);
+      document.body.appendChild(addOnFilterPanelEl);
+    }
+    const isVisible = addOnFilterPanelEl.style.display === 'flex';
+    addOnFilterPanelEl.style.display = isVisible ? 'none' : 'flex';
+  });
 
 Object.assign(document.body.style, {
     display:      'flex',

--- a/public/js/components/addOnFilter.js
+++ b/public/js/components/addOnFilter.js
@@ -106,18 +106,18 @@
   function createAddOnFilterPanel(themeStream = currentTheme){
     const panel = document.createElement('div');
     Object.assign(panel.style, {
-      position: 'absolute',
-      left: '0',
-      top: '0',
-      bottom: '0',
+      position: 'fixed',
+      top: '3rem',
+      right: '1rem',
       width: '250px',
+      maxHeight: '80vh',
       overflowY: 'auto',
       padding: '1rem',
-      boxShadow: '2px 0 6px rgba(0,0,0,0.2)',
-      display: 'flex',
+      boxShadow: '0 2px 6px rgba(0,0,0,0.2)',
       flexDirection: 'column',
       gap: '0.5rem',
-      zIndex: '1000'
+      zIndex: '1000',
+      display: 'none'
     });
 
     Object.entries(addOnTypes).forEach(([type, subtypes]) => {


### PR DESCRIPTION
## Summary
- Hide add-on filter panel by default and provide a "Filters" button to toggle it.
- Restyle filter panel so it appears fixed near the top-right and no longer occupies the left edge.

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check public/js/app.js`
- `node --check public/js/components/addOnFilter.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4d37935088328ad3a916623af807f