### PR TITLE
Align Filter button with add-on panel

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -59,8 +59,8 @@ const overlay = createDiagramOverlay(
   filterToggleBtn.textContent = 'Filters';
   Object.assign(filterToggleBtn.style, {
     position: 'fixed',
-    top: '10px',
-    right: '10px',
+    top: '0.5rem',
+    right: '1rem',
     zIndex: '1001'
   });
   document.body.appendChild(filterToggleBtn);


### PR DESCRIPTION
## Summary
- Place the Filter floating button above the add-on icon panel
- Align button horizontally with the panel using consistent spacing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4d52ca80c832899cbf818b7141d05