### PR TITLE
Adjust Add-On legend panel position

### DIFF
--- a/public/js/components/addOnLegend.js
+++ b/public/js/components/addOnLegend.js
@@ -3,7 +3,7 @@
     const container = document.createElement('div');
     Object.assign(container.style, {
       position: 'absolute',
-      top: '1rem',
+      top: 'calc(1rem + 4px)',
       right: '1rem',
       padding: '0.5rem 0.75rem',
       borderRadius: '4px',


### PR DESCRIPTION
## Summary
- Move Add-On legend panel down by 4px to improve spacing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4d6b034208328a2bb4e04076e7ec7