### PR TITLE
Avoid rendering text nodes for null-like values

### DIFF
--- a/public/js/components/elements.js
+++ b/public/js/components/elements.js
@@ -8,7 +8,11 @@ function reactiveElement(stream, renderFn = v => v) {
   function update(value) {
     placeholder.innerHTML = ''; // Clear existing content
     const rendered = renderFn(value);
-    
+    // Guard against null, undefined, or false to avoid appending text nodes
+    if (rendered == null || rendered === false) {
+      return;
+    }
+
     if (rendered instanceof Node) {
       placeholder.appendChild(rendered);
     } else if (Array.isArray(rendered)) {


### PR DESCRIPTION
## Summary
- Prevent reactiveElement from appending text nodes when render function returns null, undefined, or false

## Testing
- ⚠️ `npm test` *(missing script: "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68a5db9121b08328a2933ebf68e551ca