### PR TITLE
Embed filter toggle within add-on legend

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -56,3 +56,15 @@
 .addon-filter .selected {
   font-weight: bold;
 }
+
+/* Filter toggle button within add-on legend */
+.addon-filter-toggle {
+  padding: 0.25rem 0.5rem;
+  font-size: 14px;
+  font-family: inherit;
+  background: transparent;
+  color: inherit;
+  border: 1px solid currentColor;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -57,13 +57,7 @@ const overlay = createDiagramOverlay(
 
   const filterToggleBtn = document.createElement('button');
   filterToggleBtn.textContent = 'Filters';
-  Object.assign(filterToggleBtn.style, {
-    position: 'fixed',
-    top: '0.5rem',
-    right: '1rem',
-    zIndex: '1001'
-  });
-  document.body.appendChild(filterToggleBtn);
+  filterToggleBtn.classList.add('addon-filter-toggle');
 
   filterToggleBtn.addEventListener('click', () => {
     if (!addOnFilterPanelEl) {
@@ -217,6 +211,7 @@ Object.assign(document.body.style, {
 
   if (window.addOnLegend) {
     const legendEl = addOnLegend.createAddOnLegend(typeIcons, currentTheme);
+    legendEl.prepend(filterToggleBtn);
     document.body.appendChild(legendEl);
   }
 

--- a/public/js/components/addOnLegend.js
+++ b/public/js/components/addOnLegend.js
@@ -3,13 +3,13 @@
     const container = document.createElement('div');
     Object.assign(container.style, {
       position: 'absolute',
-      top: 'calc(1rem + 4px)',
+      top: '0.5rem',
       right: '1rem',
       padding: '0.5rem 0.75rem',
       borderRadius: '4px',
       display: 'flex',
       flexDirection: 'column',
-      gap: '0.25rem',
+      gap: '0.5rem',
       zIndex: '1000',
       fontSize: '14px'
     });


### PR DESCRIPTION
## Summary
- move filter toggle creation into legend container
- tweak legend layout to accommodate toggle
- style toggle button with reusable CSS class

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5e3953d388328b5856a9343bd4086