### PR TITLE
Store BPMN add-ons as custom attributes

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -157,11 +157,12 @@ Object.assign(document.body.style, {
 
     elementRegistry.getAll().forEach(el => {
       const bo = el.businessObject;
-      if (!bo || !bo.addOns) return;
+      const raw = bo?.$attrs?.addOns || bo?.addOns;
+      if (!raw) return;
 
       let addOns;
       try {
-        addOns = typeof bo.addOns === 'string' ? JSON.parse(bo.addOns) : bo.addOns;
+        addOns = typeof raw === 'string' ? JSON.parse(raw) : raw;
       } catch (err) {
         return;
       }
@@ -255,9 +256,10 @@ Object.assign(document.body.style, {
     addOnStore.clear();
     elementRegistry.getAll().forEach(el => {
       const bo = el.businessObject;
-      if (bo && bo.addOns) {
+      const raw = bo?.$attrs?.addOns || bo?.addOns;
+      if (raw) {
         try {
-          const data = typeof bo.addOns === 'string' ? JSON.parse(bo.addOns) : bo.addOns;
+          const data = typeof raw === 'string' ? JSON.parse(raw) : raw;
           addOnStore.setAddOns(bo.id, data);
         } catch (err) {
           console.warn('Failed to parse addOns for', bo.id, err);
@@ -270,7 +272,10 @@ Object.assign(document.body.style, {
     Object.entries(data || {}).forEach(([id, addOns]) => {
       const el = elementRegistry.get(id);
       if (el && el.businessObject) {
-        el.businessObject.addOns = JSON.stringify(addOns);
+        const bo = el.businessObject;
+        bo.$attrs = bo.$attrs || {};
+        bo.$attrs.addOns = JSON.stringify(addOns);
+        delete bo.addOns;
       }
     });
   }

--- a/public/js/components/showProperties.js
+++ b/public/js/components/showProperties.js
@@ -298,7 +298,7 @@ function showProperties(element, modeling, moddle, currentUser) {
   addOnsField.value = '';
 
   // Load existing addOns value from element
-  let existingVal = bo.addOns;
+  let existingVal = bo?.$attrs?.addOns || bo.addOns;
   if (Array.isArray(existingVal)) {
     currentAddOns = existingVal;
     addOnsField.value = JSON.stringify(currentAddOns, null, 2);
@@ -499,9 +499,17 @@ function showProperties(element, modeling, moddle, currentUser) {
         }
       });
 
-      props['addOns'] = addOnsField.value;
-
       modeling.updateProperties(element, props);
+
+      // Store addOns under $attrs for custom serialization
+      bo.$attrs = bo.$attrs || {};
+      if (addOnsField.value) {
+        bo.$attrs.addOns = addOnsField.value;
+      } else {
+        delete bo.$attrs.addOns;
+      }
+      delete bo.addOns;
+
       hideSidebar();
     },
     {


### PR DESCRIPTION
## Summary
- Persist element add-ons under `businessObject.$attrs.addOns` instead of `businessObject.addOns`
- Read and synchronize add-ons from `$attrs` with legacy fallback
- Ensure property editor saves add-ons via `$attrs`

## Testing
- `npm test` *(fails: Missing script "test")*
- `node` script verifying addOns attribute serialization and re-import

------
https://chatgpt.com/codex/tasks/task_e_68a5ecfb0b5883288efbeaad17cefd93