### PR TITLE
Ensure add-on overlays and highlights update on load

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -287,6 +287,8 @@ Object.assign(document.body.style, {
       addOnStore.setAddOns(id, addOns);
     });
     applyAddOnsToElements(data);
+    scheduleOverlayUpdate();
+    updateHighlightedNodes();
   }
 
   // Prompt user to choose path at gateways


### PR DESCRIPTION
## Summary
- Refresh overlays and highlighted nodes when loading stored add-ons

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5f19029848328b240556161ee63df