### PR TITLE
Validate add-on JSON before saving

### DIFF
--- a/public/js/components/showProperties.js
+++ b/public/js/components/showProperties.js
@@ -488,6 +488,19 @@ function showProperties(element, modeling, moddle, currentUser) {
   const saveBtn = reactiveButton(
     new Stream('Save'),
     () => {
+      let parsedAddOns = [];
+      try {
+        parsedAddOns = addOnsField.value ? JSON.parse(addOnsField.value) : [];
+        currentAddOns = parsedAddOns;
+        addOnsField.value = JSON.stringify(currentAddOns, null, 2);
+        if (window.addOnStore) {
+          addOnStore.setAddOns(bo.id, currentAddOns);
+        }
+      } catch (e) {
+        alert('AddOns must be valid JSON');
+        return;
+      }
+
       const data = new FormData(form);
       const props = {};
       const standardKeys = BPMN_PROPERTY_MAP[bo.$type] || [];


### PR DESCRIPTION
## Summary
- validate and parse hidden add-on field before saving
- show alert and skip saving when add-on JSON is invalid
- keep store and hidden field in sync after parsing

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a5f7b32f2c832899ae76d2208045aa