### PR TITLE
feat: add close button for add-on filter panel

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -68,3 +68,16 @@
   border-radius: 4px;
   cursor: pointer;
 }
+
+/* Close button inside add-on filter panel */
+.addon-filter-close {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -65,6 +65,10 @@ const overlay = createDiagramOverlay(
       document.body.appendChild(addOnFilterPanelEl);
     }
     const isVisible = addOnFilterPanelEl.style.display === 'flex';
+    if (isVisible) {
+      selectedType.set(null);
+      selectedSubtype.set(null);
+    }
     addOnFilterPanelEl.style.display = isVisible ? 'none' : 'flex';
   });
 

--- a/public/js/components/addOnFilter.js
+++ b/public/js/components/addOnFilter.js
@@ -121,8 +121,19 @@
       display: 'none'
     });
 
+    const closeBtn = document.createElement('button');
+    closeBtn.textContent = '\u00d7';
+    closeBtn.className = 'addon-filter-close';
+    closeBtn.addEventListener('click', () => {
+      panel.style.display = 'none';
+      selectedType.set(null);
+      selectedSubtype.set(null);
+      expandedType.set(null);
+    });
+
     const list = document.createElement('ul');
     panel.appendChild(list);
+    panel.prepend(closeBtn);
 
     Object.entries(addOnTypes).forEach(([type, subtypes]) => {
       const typeItem = document.createElement('li');


### PR DESCRIPTION
## Summary
- add close button to add-on filter panel that resets selection state
- clear highlights when hiding filter panel via toggle
- style add-on filter close button

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5ffc5aa188328a992f3037dc57061