### PR TITLE
feat: show newest diagram versions first

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -623,9 +623,9 @@ function buildDropdownOptions() {
               const versionChoices = versions.map((ver, index) => ({
                 value: index.toString(),
                 label: `Version ${index + 1} — ${new Date(ver.timestamp).toLocaleString()}`
-              }));
+              })).reverse();
 
-              versionStream.set("0"); // Default to latest version
+              versionStream.set((versions.length - 1).toString()); // Default to latest version
               const dropdown = dropdownStream(versionStream, {
                 choices: versionChoices,
                 width: '100%',

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -461,14 +461,14 @@ function promptDiagramMetadata(initialName = '', initialNotes = '', themeStream 
 
 
 function selectVersionModal(diagramName, versions, themeStream = currentTheme) {
-  const versionStream = new Stream("0"); // Default to latest
+  const versionStream = new Stream((versions.length - 1).toString()); // Default to latest
   const pickStream = new Stream(null);   // Emits selected version index
 
   // Choices for dropdown
   const versionChoices = versions.map((ver, index) => ({
     value: index.toString(),
     label: `Version ${index + 1} — ${new Date(ver.timestamp).toLocaleString()}`
-  }));
+  })).reverse();
 
   const dropdown = dropdownStream(versionStream, {
     choices: versionChoices,


### PR DESCRIPTION
## Summary
- Display version selection menus with newest versions first when choosing diagrams or switching versions.
- Default version selection now points to the most recent version.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a61f0998788328b9ffb8628b46245f