### PR TITLE
fix: slide-in properties sidebar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -46,9 +46,9 @@
 
   /* properties sidebar */
   .props-sidebar {
-    position: absolute;
+    position: fixed;
     top: 0;
-    right: 0;
+    right: -100%;
     height: 100%;
     background: #fff;
     box-shadow: -2px 0 6px rgba(0,0,0,0.2);
@@ -57,14 +57,13 @@
     overflow-x: hidden;
     display: flex;
     flex-direction: column;
-    transition: transform 0.3s;
+    transition: right 0.3s;
     z-index: 1100;
     width: 300px;
-    transform: translateX(100%);
   }
 
   .props-sidebar.open {
-    transform: translateX(0);
+    right: 0;
   }
 
   @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- position properties sidebar using `fixed` and `right` offsets
- open state slides panel into view without transforms

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a624a3f75c8328b44aeddb9300407a