### PR TITLE
Disable document scrolling on mobile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -27,13 +27,18 @@
   }
 
   html, body {
-    overflow-x: hidden;
+    overflow: hidden;
     width: 100%;
   }
 
   body {
     display: flex;
     flex-direction: column;
+  }
+
+  #canvas {
+    touch-action: none;
+    overflow: hidden;
   }
 
   #diagram-wrapper {


### PR DESCRIPTION
## Summary
- Prevent the overall page from scrolling by hiding overflow on `html` and `body`
- Ensure BPMN canvas handles touch gestures with `touch-action: none`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6256372b88328968731d73b4ebbf2