### PR TITLE
Hide properties sidebar when not in use

### DIFF
--- a/public/js/components/showProperties.js
+++ b/public/js/components/showProperties.js
@@ -642,6 +642,7 @@ function showProperties(element, modeling, moddle, currentUser) {
 
 
   propsSidebar.append(form);
+  propsSidebar.style.display = 'flex';
   propsSidebar.classList.add('open');
 
   const unsub = currentTheme.subscribe(theme => {
@@ -689,9 +690,10 @@ function getOrCreateExtEl(bo, moddle) {
   // hide helper cleans up subscription
   function hideSidebar() {
     propsSidebar.classList.remove('open');
+    propsSidebar.style.display = 'none';
     if (propsSidebar._unsubTheme) {
       propsSidebar._unsubTheme();
-      delete propsSidebar._unsubTheme;      
+      delete propsSidebar._unsubTheme;
     }
   }
 


### PR DESCRIPTION
## Summary
- Toggle properties sidebar `display` so it's removed from layout when closed
- Ensure sidebar sets `display: flex` before opening

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a6263ef69c832887bf6b73b6ded671