### PR TITLE
Prevent page scrolling during touch interactions on BPMN canvas

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -41,6 +41,12 @@
     overflow: hidden;
   }
 
+  #canvas .djs-container,
+  #canvas .djs-container svg {
+    touch-action: none;
+    overflow: hidden;
+  }
+
   #diagram-wrapper {
     display: flex;
     flex: 1;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -85,6 +85,12 @@ Object.assign(document.body.style, {
 
   // ─── build canvas + xml-editor elements ────────────────────────────────────
   const canvasEl = document.getElementById('canvas');
+
+  canvasEl.addEventListener(
+    'touchmove',
+    e => e.preventDefault(),
+    { passive: false }
+  );
   const header   = document.querySelector('header');
 
   const setCanvasHeight = () => {


### PR DESCRIPTION
## Summary
- prevent default touchmove to avoid page scroll while dragging
- disable touch actions on BPMN canvas containers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6290c973483289088e9bd5893b07c