### PR TITLE
refactor: rely on CSS for touch interactions

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -86,9 +86,18 @@ Object.assign(document.body.style, {
   // ─── build canvas + xml-editor elements ────────────────────────────────────
   const canvasEl = document.getElementById('canvas');
 
-  canvasEl.addEventListener(
+  // Touch interactions are handled via CSS (see `touch-action: none`).
+  // Previously, we suppressed page scrolling by preventing the default
+  // `touchmove` behavior on the canvas element which also blocked BPMN's
+  // internal handlers. Rely on CSS instead and only prevent scrolling when
+  // touches originate outside the BPMN diagram container.
+  document.addEventListener(
     'touchmove',
-    e => e.preventDefault(),
+    e => {
+      if (!e.target.closest('.djs-container')) {
+        e.preventDefault();
+      }
+    },
     { passive: false }
   );
   const header   = document.querySelector('header');


### PR DESCRIPTION
## Summary
- remove canvas-level touchmove preventDefault handler
- rely on CSS `touch-action: none` to suppress scroll
- only block touchmove when target lies outside BPMN container

## Testing
- `npm test` *(fails: Missing script "test" )*


------
https://chatgpt.com/codex/tasks/task_e_68a62ac715dc83289cbc71ba7f62132f