### PR TITLE
fix: include padding in tree panel width

### DIFF
--- a/public/js/components/layout.js
+++ b/public/js/components/layout.js
@@ -123,6 +123,7 @@ window.addEventListener('DOMContentLoaded', () => {
   panel.style.top = '0';
   panel.style.left = '-300px';
   panel.style.width = '300px';
+  panel.style.boxSizing = 'border-box';
   panel.style.height = '100%';
   panel.style.background = '#fff';
   panel.style.boxShadow = '2px 0 6px rgba(0,0,0,0.2)';


### PR DESCRIPTION
## Summary
- ensure diagram tree panel width includes padding by adding `box-sizing: border-box`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a65d4f07648328b6deb2845d802133