### PR TITLE
Sync diagram tree with canvas selection

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -57,6 +57,10 @@
   font-weight: bold;
 }
 
+.diagram-tree-selected {
+  background: #ffd54f;
+}
+
 /* Filter toggle button within add-on legend */
 .addon-filter-toggle {
   padding: 0.25rem 0.5rem;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -166,6 +166,20 @@ Object.assign(document.body.style, {
   const simulation      = createSimulation({ elementRegistry, canvas });
   const overlays        = modeler.get('overlays');
 
+  window.diagramTree.onSelect = id => {
+    const element = elementRegistry.get(id);
+    if (element) {
+      selectionService.select(element);
+      showProperties(element, modeling, moddle, currentUser);
+    }
+    window.diagramTree.setSelectedId(id);
+  };
+
+  eventBus.on('selection.changed', ({ newSelection }) => {
+    const element = newSelection[0];
+    window.diagramTree.setSelectedId(element?.id || null);
+  });
+
   function updateDiagramTree() {
     const registry = modeler.get('elementRegistry');
     const root = registry.getAll().find(el => el.type === 'bpmn:Process');

--- a/public/js/components/diagramTree.js
+++ b/public/js/components/diagramTree.js
@@ -1,9 +1,24 @@
 (function(global){
   const treeStream = new Stream(null);
+  let selectedId = null;
+
+  function setSelectedId(id){
+    selectedId = id;
+    treeStream.set(treeStream.get());
+  }
 
   function renderNode(node){
     const li = document.createElement('li');
     li.textContent = node.name || node.id;
+    li.dataset.elementId = node.id;
+    li.addEventListener('click', e => {
+      e.stopPropagation();
+      global.diagramTree.onSelect?.(node.id);
+    });
+
+    if (node.id === selectedId){
+      li.classList.add('diagram-tree-selected');
+    }
 
     if (node.children && node.children.length){
       const ul = document.createElement('ul');
@@ -31,6 +46,9 @@
 
   global.diagramTree = {
     treeStream,
-    createTreeContainer
+    createTreeContainer,
+    onSelect: () => {},
+    setSelectedId,
+    get selectedId(){ return selectedId; }
   };
 })(window);


### PR DESCRIPTION
## Summary
- Track a selected diagram tree node and rerender highlights
- Invoke modeler selection and show properties when tree nodes are clicked
- Highlight selected tree node with new `.diagram-tree-selected` style

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a65f0265f88328a3f3cb7103ec657e