### PR TITLE
feat: include owner in diagram tree

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -61,6 +61,11 @@
   background: #ffd54f;
 }
 
+.diagram-tree-owner {
+  font-style: italic;
+  opacity: 0.7;
+}
+
 /* Filter toggle button within add-on legend */
 .addon-filter-toggle {
   padding: 0.25rem 0.5rem;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -194,6 +194,8 @@ Object.assign(document.body.style, {
       if (!node || visited.has(node.id)) return null;
       visited.add(node.id);
 
+      const owner = node.businessObject?.get('ownerRole') || '';
+
       const children = (node.children || [])
         .map(build)
         .filter(Boolean);
@@ -201,6 +203,7 @@ Object.assign(document.body.style, {
       return {
         id: node.id,
         name: node.businessObject?.name || '',
+        owner,
         children
       };
     }

--- a/public/js/components/diagramTree.js
+++ b/public/js/components/diagramTree.js
@@ -9,7 +9,16 @@
 
   function renderNode(node){
     const li = document.createElement('li');
-    li.textContent = node.name || node.id;
+    const label = node.name || node.id;
+    if (node.owner){
+      li.textContent = label + ' ';
+      const ownerSpan = document.createElement('span');
+      ownerSpan.className = 'diagram-tree-owner';
+      ownerSpan.textContent = `(${node.owner})`;
+      li.appendChild(ownerSpan);
+    } else {
+      li.textContent = label;
+    }
     li.dataset.elementId = node.id;
     li.addEventListener('click', e => {
       e.stopPropagation();


### PR DESCRIPTION
## Summary
- display BPMN element owners in diagram tree
- style owner text in tree view

## Testing
- `npm test` *(fails: Missing script 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68a66015742c83289f6e5fdda873b550