### PR TITLE
style: enhance diagram tree panel

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -66,6 +66,59 @@
   opacity: 0.7;
 }
 
+/* Diagram tree type indicators */
+.diagram-tree-item::before {
+  display: inline-block;
+  width: 1rem;
+  margin-right: 0.25rem;
+  text-align: center;
+}
+
+.diagram-tree-kind-node::before {
+  content: '\25A0'; /* black square */
+}
+
+.diagram-tree-kind-line::before {
+  content: '\27A4'; /* arrow */
+}
+
+.diagram-tree-kind-text::before {
+  content: '\270E'; /* pencil */
+}
+
+/* Diagram tree panel and controls */
+.diagram-tree-panel {
+  position: fixed;
+  top: 0;
+  left: -300px;
+  width: 300px;
+  box-sizing: border-box;
+  height: 100%;
+  overflow-y: auto;
+  transition: left 0.3s;
+  z-index: 1000;
+  padding: 1rem;
+}
+
+.diagram-tree-toggle {
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  z-index: 1001;
+}
+
+.diagram-tree-close {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
 /* Filter toggle button within add-on legend */
 .addon-filter-toggle {
   padding: 0.25rem 0.5rem;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -196,6 +196,14 @@ Object.assign(document.body.style, {
 
       const owner = node.businessObject?.get('ownerRole') || '';
 
+      // Classify element type for tree rendering
+      let kind = 'node';
+      if (node.type === 'label' || node.businessObject?.$type === 'bpmn:TextAnnotation') {
+        kind = 'text';
+      } else if (node.waypoints) {
+        kind = 'line';
+      }
+
       const children = (node.children || [])
         .map(build)
         .filter(Boolean);
@@ -204,6 +212,7 @@ Object.assign(document.body.style, {
         id: node.id,
         name: node.businessObject?.name || '',
         owner,
+        kind,
         children
       };
     }

--- a/public/js/components/diagramTree.js
+++ b/public/js/components/diagramTree.js
@@ -9,6 +9,7 @@
 
   function renderNode(node){
     const li = document.createElement('li');
+    li.classList.add('diagram-tree-item', `diagram-tree-kind-${node.kind || 'node'}`);
     const label = node.name || node.id;
     if (node.owner){
       li.textContent = label + ' ';

--- a/public/js/components/layout.js
+++ b/public/js/components/layout.js
@@ -119,18 +119,15 @@ window.addEventListener('DOMContentLoaded', () => {
   if (!window.diagramTree) return;
 
   const panel = document.createElement('div');
-  panel.style.position = 'fixed';
-  panel.style.top = '0';
-  panel.style.left = '-300px';
-  panel.style.width = '300px';
-  panel.style.boxSizing = 'border-box';
-  panel.style.height = '100%';
-  panel.style.background = '#fff';
-  panel.style.boxShadow = '2px 0 6px rgba(0,0,0,0.2)';
-  panel.style.overflowY = 'auto';
-  panel.style.transition = 'left 0.3s';
-  panel.style.zIndex = '1000';
-  panel.style.padding = '1rem';
+  panel.classList.add('diagram-tree-panel');
+
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = '\u00D7';
+  closeBtn.classList.add('diagram-tree-close');
+  closeBtn.addEventListener('click', () => {
+    panel.style.left = '-300px';
+  });
+  panel.appendChild(closeBtn);
 
   const content = window.diagramTree.createTreeContainer();
   panel.appendChild(content);
@@ -144,6 +141,21 @@ window.addEventListener('DOMContentLoaded', () => {
     panel.style.left = open ? '-300px' : '0px';
   });
 
-  const header = document.querySelector('header') || document.body;
-  header.appendChild(btn);
+  document.body.appendChild(btn);
+
+  // Apply theme styling
+  currentTheme.subscribe(theme => {
+    const colors = theme.colors;
+    panel.style.background = colors.surface;
+    panel.style.color = colors.foreground;
+    panel.style.boxShadow = `2px 0 6px ${colors.border}`;
+
+    btn.style.backgroundColor = colors.primary;
+    btn.style.color = colors.foreground;
+    btn.style.border = `1px solid ${colors.border}`;
+
+    closeBtn.style.background = 'transparent';
+    closeBtn.style.color = colors.foreground;
+    closeBtn.style.border = 'none';
+  });
 });


### PR DESCRIPTION
## Summary
- classify diagram elements as nodes, lines, or text and show icons in the tree
- add theme-aware tree panel with close button and styled toggle control
- apply theme colors to tree toggle button at the bottom of the screen

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6614edbc483289209800a2366d097