### PR TITLE
Move diagram tree button to bottom right

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -102,8 +102,8 @@
 
 .diagram-tree-toggle {
   position: fixed;
-  bottom: 1rem;
-  left: 1rem;
+  bottom: 3rem;
+  right: 1rem;
   padding: 0.5rem 1rem;
   border-radius: 4px;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- Reposition diagram tree toggle button to bottom-right to sit above the BPMN logo.

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a728901cf48328ab377a440dce4bab