### PR TITLE
Improve dark theme contrast

### DIFF
--- a/public/js/core/theme.js
+++ b/public/js/core/theme.js
@@ -5,14 +5,14 @@ const themes = {
     name: 'Dark',
     colors: {
       background: '#121212',
-      foreground: '#333',
+      foreground: '#f0f0f0',
       primary:    '#1e1e1e',
       accent:     '#bb86fc',
       surface:    '#1e1e1e',
-      border:     '#333'
+      border:     '#666'
     },
     bpmn: {
-      shape:      { fill: '#1e1e1e', stroke: '#333', strokeWidth: 2 },
+      shape:      { fill: '#1e1e1e', stroke: '#666', strokeWidth: 2 },
       connection: { stroke: '#f0f0f0', strokeWidth: 2 },
       marker:     { fill: '#f0f0f0', stroke: '#f0f0f0' },
       label:      { fontFamily: 'system-ui, sans-serif', fill: '#f0f0f0' },


### PR DESCRIPTION
## Summary
- use light gray foreground in dark theme
- increase border contrast and update BPMN shape stroke

## Testing
- `npm test` *(fails: Missing script "test")*
- `node -e "function luminance(hex){hex=hex.replace('#','');var r=parseInt(hex.substr(0,2),16)/255;var g=parseInt(hex.substr(2,2),16)/255;var b=parseInt(hex.substr(4,2),16)/255;var a=[r,g,b].map(c=>c<=0.03928?c/12.92:Math.pow((c+0.055)/1.055,2.4));return 0.2126*a[0]+0.7152*a[1]+0.0722*a[2];}function contrast(hex1,hex2){var l1=luminance(hex1);var l2=luminance(hex2);var lighter=Math.max(l1,l2);var darker=Math.min(l1,l2);return (lighter+0.05)/(darker+0.05);}console.log('bg',contrast('#f0f0f0','#121212').toFixed(2));console.log('primary',contrast('#f0f0f0','#1e1e1e').toFixed(2));console.log('surface',contrast('#f0f0f0','#1e1e1e').toFixed(2));console.log('border',contrast('#f0f0f0','#666666').toFixed(2));"`

------
https://chatgpt.com/codex/tasks/task_e_68a77f20d874832889ebb065df417e28