### PR TITLE
feat: brighten matrix theme toggle colors

### DIFF
--- a/public/js/components/elements.js
+++ b/public/js/components/elements.js
@@ -209,7 +209,9 @@ function toggleSwitch(stream, options = {}, themeStream = currentTheme) {
 
     applyTheme(wrapper, options);
 
-    const onColor = options.onColor || colors.primary || '#4CAF50';
+    // Prefer a bright accent color for the "on" state to ensure contrast,
+    // falling back to the theme's primary or a default green.
+    const onColor = options.onColor || colors.accent || colors.primary || '#4CAF50';
     const offColor = options.offColor || colors.background || '#888';
     const knobColor = options.knobColor || '#fff';
 

--- a/public/js/core/theme.js
+++ b/public/js/core/theme.js
@@ -213,7 +213,7 @@ const themes = {
     colors: {
       background: '#000000',
       foreground: '#00ff00',
-      primary:    '#001100',
+      primary:    '#004400',
       accent:     '#00ff00',
       surface:    '#002200',
       border:     '#00aa00'


### PR DESCRIPTION
## Summary
- brighten Matrix theme primary color for better contrast
- prefer accent color for toggle switches to ensure visible "on" state

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7801acf4c8328b466fc21d05e8b65