### PR TITLE
Improve direct editing theme styling

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,3 +1,11 @@
+.djs-direct-editing-parent,
+.djs-direct-editing-content {
+  background: #1e1e1e;
+  color: #f0f0f0;
+  border: 1px solid #666;
+  outline: 1px solid #666;
+}
+
 .djs-element.bpmn-addOn-highlight .djs-visual > :nth-child(1) {
   stroke: #ff9800;
   stroke-width: 4px;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1035,6 +1035,15 @@ currentTheme.subscribe(theme => {
       stroke: orange !important;
       stroke-width: 4px !important;
     }
+
+    /* ── direct editing overlay ───────────────────────────────────────── */
+    .djs-direct-editing-parent,
+    .djs-direct-editing-content {
+      background: ${colors.surface} !important;
+      color: ${colors.foreground} !important;
+      border: 1px solid ${colors.border} !important;
+      outline: 1px solid ${colors.border} !important;
+    }
   `;
 });
 


### PR DESCRIPTION
## Summary
- Style BPMN direct editing overlay with current theme colors
- Provide dark-theme fallback CSS for direct editing before JS loads

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a79764a35c83288e0b03bafac93637