### PR TITLE
Fix root lookup for diagram tree

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -182,7 +182,11 @@ Object.assign(document.body.style, {
 
   function updateDiagramTree() {
     const registry = modeler.get('elementRegistry');
-    const root = registry.getAll().find(el => el.type === 'bpmn:Process');
+    const canvas = modeler.get('canvas');
+    let root = canvas.getRootElement();
+    if (root.type === 'bpmn:Collaboration' && root.children?.length) {
+      root = root.children[0]; // pick first participant/process
+    }
     if (!root) {
       window.diagramTree?.treeStream.set(null);
       return;


### PR DESCRIPTION
## Summary
- improve root element selection in diagram tree to handle collaboration diagrams

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a79eec47cc832880399e0734d30680