### PR TITLE
Safeguard token marker updates

### DIFF
--- a/public/js/core/simulation.js
+++ b/public/js/core/simulation.js
@@ -23,7 +23,7 @@ function createSimulation(services, opts = {}) {
   let previousId = null;
   tokenStream.subscribe(el => {
     const id = el && el.id;
-    if (previousId) {
+    if (previousId && elementRegistry.get(previousId)) {
       canvas.removeMarker(previousId, 'active');
     }
     if (id) {
@@ -107,6 +107,10 @@ function createSimulation(services, opts = {}) {
 
   function reset() {
     pause();
+    if (previousId && elementRegistry.get(previousId)) {
+      canvas.removeMarker(previousId, 'active');
+    }
+    previousId = null;
     current = getStart();
     tokenStream.set(current);
     pathsStream.set(null);


### PR DESCRIPTION
## Summary
- avoid removing markers for non-existent elements in simulation token stream
- clear previous marker and reset tracking id on simulation reset

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7a07118148328877f1adfd99697f5