### PR TITLE
Add start event to default BPMN template

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -26,11 +26,30 @@ const defaultXml = `<?xml version="1.0" encoding="UTF-8"?>
   <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
                     xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
                     xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                    xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
                     id="Definitions_1">
     <bpmn:process id="Process_1" isExecutable="true">
+      <bpmn:startEvent id="StartEvent_1">
+        <bpmn:outgoing>Flow_1</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:endEvent id="EndEvent_1">
+        <bpmn:incoming>Flow_1</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />
     </bpmn:process>
     <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-      <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1"/>
+      <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+        <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+          <dc:Bounds x="173" y="81" width="36" height="36" />
+        </bpmndi:BPMNShape>
+        <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+          <dc:Bounds x="329" y="81" width="36" height="36" />
+        </bpmndi:BPMNShape>
+        <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+          <di:waypoint x="209" y="99" />
+          <di:waypoint x="329" y="99" />
+        </bpmndi:BPMNEdge>
+      </bpmndi:BPMNPlane>
     </bpmndi:BPMNDiagram>
   </bpmn:definitions>`;
 


### PR DESCRIPTION
## Summary
- ensure default BPMN XML includes a start and end event connected by a sequence flow

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7a18352848328875fef516be401a3