### PR TITLE
Add token log panel to show simulation tokens

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -174,6 +174,7 @@
   <script src="js/components/showProperties.js"></script>
   <script src="js/components/addOnFilter.js"></script>
   <script src="js/components/addOnLegend.js"></script>
+  <script src="js/components/tokenListPanel.js"></script>
   <!-- 6) Your application code -->
   <script src="js/firebase.js"></script>
   <script src="js/login.js"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -185,6 +185,28 @@ Object.assign(document.body.style, {
   const simulation      = createSimulation({ elementRegistry, canvas });
   const overlays        = modeler.get('overlays');
 
+  // Token list panel for simulation log
+  const tokenPanel = window.tokenListPanel
+    .createTokenListPanel(simulation.tokenLogStream, currentTheme);
+  document.body.appendChild(tokenPanel.el);
+
+  const origStart = simulation.start;
+  simulation.start = (...args) => {
+    tokenPanel.show();
+    return origStart.apply(simulation, args);
+  };
+
+  const origReset = simulation.reset;
+  simulation.reset = (...args) => {
+    const res = origReset.apply(simulation, args);
+    tokenPanel.hide();
+    return res;
+  };
+
+  simulation.tokenLogStream.subscribe(entries => {
+    if (!entries.length) tokenPanel.hide();
+  });
+
   window.diagramTree.onSelect = id => {
     const element = elementRegistry.get(id);
     if (element) {

--- a/public/js/components/tokenListPanel.js
+++ b/public/js/components/tokenListPanel.js
@@ -1,0 +1,70 @@
+(function(global){
+  function createTokenListPanel(logStream, themeStream = currentTheme){
+    const panel = document.createElement('div');
+    Object.assign(panel.style, {
+      position: 'fixed',
+      bottom: '1rem',
+      right: '1rem',
+      width: '250px',
+      maxHeight: '200px',
+      overflowY: 'auto',
+      padding: '0.5rem',
+      borderRadius: '4px',
+      boxShadow: '0 2px 6px rgba(0,0,0,0.2)',
+      display: 'none',
+      zIndex: '1000',
+      fontSize: '14px'
+    });
+
+    const list = document.createElement('ul');
+    Object.assign(list.style, {
+      listStyle: 'none',
+      margin: 0,
+      padding: 0,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '0.25rem'
+    });
+    panel.appendChild(list);
+
+    function render(entries){
+      list.innerHTML = '';
+      entries.forEach(entry => {
+        const li = document.createElement('li');
+        const time = new Date(entry.timestamp).toLocaleTimeString();
+        const namePart = entry.elementName ? ` - ${entry.elementName}` : '';
+        li.textContent = `${time}: ${entry.elementId}${namePart}`;
+        list.appendChild(li);
+      });
+      panel.style.display = entries.length ? 'block' : 'none';
+      if(entries.length){
+        panel.scrollTop = panel.scrollHeight;
+      }
+    }
+
+    const unsubscribe = logStream.subscribe(render);
+
+    themeStream.subscribe(theme => {
+      panel.style.background = theme.colors.surface;
+      panel.style.color = theme.colors.foreground;
+      panel.style.border = `1px solid ${theme.colors.border}`;
+      panel.style.fontFamily = theme.fonts.base || 'sans-serif';
+    });
+
+    function show(){
+      if(list.children.length){
+        panel.style.display = 'block';
+      }
+    }
+
+    function hide(){
+      panel.style.display = 'none';
+    }
+
+    observeDOMRemoval(panel, unsubscribe);
+
+    return { el: panel, show, hide };
+  }
+
+  global.tokenListPanel = { createTokenListPanel };
+})(window);


### PR DESCRIPTION
## Summary
- add tokenListPanel component for displaying token log entries
- wire panel into app to show on simulation start and hide on reset or empty log
- include tokenListPanel script in index

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7a8452e04832885a8060ee64c6a7f