### PR TITLE
fix: ensure simulation list overlays tree button

### DIFF
--- a/public/js/components/tokenListPanel.js
+++ b/public/js/components/tokenListPanel.js
@@ -62,11 +62,17 @@
     const treeBtn = document.querySelector('.diagram-tree-toggle');
     if(treeBtn){
       const styles = window.getComputedStyle(treeBtn);
-      const btnBottom = parseFloat(styles.bottom) || 0;
-      const btnHeight = treeBtn.offsetHeight || 0;
+      const rect = treeBtn.getBoundingClientRect();
       const gap = 8; // px
-      panel.style.bottom = `${btnBottom + btnHeight + gap}px`;
+
+      // place the panel above the tree button using pixel values
+      const bottomOffset = (window.innerHeight - rect.bottom) + rect.height + gap;
+      panel.style.bottom = `${bottomOffset}px`;
       panel.style.right = styles.right;
+
+      // ensure the panel appears above the tree button
+      const zIndex = parseInt(styles.zIndex || '0', 10);
+      panel.style.zIndex = String(zIndex + 1);
     }
 
     themeStream.subscribe(theme => {


### PR DESCRIPTION
## Summary
- adjust token list panel positioning and z-index so it stacks above the tree toggle button when visible

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_68a7aad77d3483288273d398c3c35f2d