### PR TITLE
Clear token log when panel closes

### DIFF
--- a/public/js/components/tokenListPanel.js
+++ b/public/js/components/tokenListPanel.js
@@ -88,8 +88,15 @@
       }
     }
 
+    let clearing = false;
+
     function hide(){
       panel.style.display = 'none';
+      if(!clearing && logStream.get().length){
+        clearing = true;
+        logStream.set([]);
+        clearing = false;
+      }
     }
 
     closeBtn.addEventListener('click', hide);


### PR DESCRIPTION
## Summary
- clear token log stream whenever the token list panel is hidden
- prevent recursive hide calls when emptying the log

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a870087d508328bd2fe1775ed45668