### PR TITLE
Position simulation list above tree button

### DIFF
--- a/public/js/components/tokenListPanel.js
+++ b/public/js/components/tokenListPanel.js
@@ -62,11 +62,11 @@
     const treeBtn = document.querySelector('.diagram-tree-toggle');
     if(treeBtn){
       const styles = window.getComputedStyle(treeBtn);
-      const rect = treeBtn.getBoundingClientRect();
       const gap = 8; // px
 
-      // place the panel above the tree button using pixel values
-      const bottomOffset = (window.innerHeight - rect.bottom) + rect.height + gap;
+      // position the panel above the tree button
+      const bottom = parseFloat(styles.bottom) || 0;
+      const bottomOffset = bottom + treeBtn.offsetHeight + gap;
       panel.style.bottom = `${bottomOffset}px`;
       panel.style.right = styles.right;
 


### PR DESCRIPTION
## Summary
- ensure the simulation token list panel sits above the tree toggle button by calculating its offset from the button's bottom position

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a87223ffc883288cb1852d0a5d3fbc