### PR TITLE
Hide tree button during simulation

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -190,6 +190,21 @@ Object.assign(document.body.style, {
     .createTokenListPanel(simulation.tokenLogStream, currentTheme);
   document.body.appendChild(tokenPanel.el);
 
+  const treeBtn = document.querySelector('.diagram-tree-toggle');
+
+  const origPanelShow = tokenPanel.show;
+  tokenPanel.show = (...args) => {
+    if (treeBtn) treeBtn.style.display = 'none';
+    return origPanelShow.apply(tokenPanel, args);
+  };
+
+  const origPanelHide = tokenPanel.hide;
+  tokenPanel.hide = (...args) => {
+    const res = origPanelHide.apply(tokenPanel, args);
+    if (treeBtn) treeBtn.style.display = '';
+    return res;
+  };
+
   const origStart = simulation.start;
   simulation.start = (...args) => {
     tokenPanel.show();


### PR DESCRIPTION
## Summary
- Hide the diagram tree toggle whenever a simulation starts
- Restore the tree button when the simulation list panel closes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a87559843083288ace0b0ad52e990f