### PR TITLE
feat: support multi-token simulation

### DIFF
--- a/public/js/components/tokenListPanel.js
+++ b/public/js/components/tokenListPanel.js
@@ -48,7 +48,8 @@
         const li = document.createElement('li');
         const time = new Date(entry.timestamp).toLocaleTimeString();
         const namePart = entry.elementName ? ` - ${entry.elementName}` : '';
-        li.textContent = `${time}: ${entry.elementId}${namePart}`;
+        const idPart = entry.tokenId != null ? `[${entry.tokenId}] ` : '';
+        li.textContent = `${time} ${idPart}${entry.elementId}${namePart}`;
         list.appendChild(li);
       });
       panel.style.display = entries.length ? 'block' : 'none';


### PR DESCRIPTION
## Summary
- Allow multiple tokens in simulation via token list stream
- Log token IDs and update token panel UI
- Add join handling for gateways to wait for all incoming tokens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c13d9ef483288fcd1043b96e320b