### PR TITLE
Reset simulation state on start and improve token panel handling

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -218,9 +218,13 @@ Object.assign(document.body.style, {
     return res;
   };
 
-  simulation.tokenLogStream.subscribe(entries => {
-    if (!entries.length) tokenPanel.hide();
-  });
+    simulation.tokenLogStream.subscribe(entries => {
+      if (entries.length) {
+        tokenPanel.show();
+      } else {
+        tokenPanel.hide();
+      }
+    });
 
   window.diagramTree.onSelect = id => {
     const element = elementRegistry.get(id);

--- a/public/js/core/simulation.js
+++ b/public/js/core/simulation.js
@@ -321,7 +321,19 @@ function createSimulation(services, opts = {}) {
   }
 
   function start() {
+    if (tokens.length && !running) {
+      stop();
+    }
+
     clearHandlerState();
+    tokenLogStream.set([]);
+    pathsStream.set(null);
+    awaitingToken = null;
+    previousIds.forEach(id => {
+      if (elementRegistry.get(id)) canvas.removeMarker(id, 'active');
+    });
+    previousIds = new Set();
+
     if (!tokens.length) {
       const startEl = getStart();
       const t = { id: nextTokenId++, element: startEl };


### PR DESCRIPTION
## Summary
- Ensure simulation start resets token and path streams, clears markers, and resets awaiting token
- Auto-stop lingering tokens before starting new simulation
- Show or hide token log panel based on token log stream

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8ed4555588328b50635c0a51e35f9