### PR TITLE
Handle ExclusiveGateway tokens individually

### DIFF
--- a/public/js/core/simulation.js
+++ b/public/js/core/simulation.js
@@ -279,7 +279,8 @@ function createSimulation(services, opts = {}) {
       if (processed.has(token.id)) continue;
       const el = token.element;
       const incomingCount = (el.incoming || []).length;
-      if (incomingCount > 1) {
+      const type = el.type;
+      if (incomingCount > 1 && (type === 'bpmn:ParallelGateway' || type === 'bpmn:InclusiveGateway')) {
         const group = tokens.filter(t => t.element.id === el.id);
         group.forEach(t => processed.add(t.id));
         const expected = group[0].pendingJoins?.[el.id] || incomingCount;


### PR DESCRIPTION
## Summary
- Avoid grouping tokens at exclusive gateways; only parallel and inclusive gateways perform join logic.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8f0e62c488328a3108818b512e06e