### PR TITLE
Keep token panel visible after simulation

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -214,15 +214,12 @@ Object.assign(document.body.style, {
   const origReset = simulation.reset;
   simulation.reset = (...args) => {
     const res = origReset.apply(simulation, args);
-    tokenPanel.hide();
     return res;
   };
 
     simulation.tokenLogStream.subscribe(entries => {
       if (entries.length) {
         tokenPanel.show();
-      } else {
-        tokenPanel.hide();
       }
     });
 

--- a/public/js/components/tokenListPanel.js
+++ b/public/js/components/tokenListPanel.js
@@ -52,8 +52,8 @@
         li.textContent = `${time} ${idPart}${entry.elementId}${namePart}`;
         list.appendChild(li);
       });
-      panel.style.display = entries.length ? 'block' : 'none';
       if(entries.length){
+        panel.style.display = 'block';
         panel.scrollTop = panel.scrollHeight;
       }
     }


### PR DESCRIPTION
## Summary
- Ensure token log panel only shows when entries exist instead of hiding when empty
- Remove automatic hiding of token panel on simulation reset or empty logs

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9e42abee48328b3faf526fad3b8d8