### PR TITLE
refactor: stop clearing log when token panel hides

### DIFF
--- a/public/js/components/tokenListPanel.js
+++ b/public/js/components/tokenListPanel.js
@@ -95,15 +95,8 @@
       }
     }
 
-    let clearing = false;
-
     function hide(){
       panel.style.display = 'none';
-      if(!clearing && logStream.get().length){
-        clearing = true;
-        logStream.set([]);
-        clearing = false;
-      }
     }
 
     closeBtn.addEventListener('click', hide);


### PR DESCRIPTION
## Summary
- avoid wiping token log when panel hides by removing logStream reset

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9f3293f588328aac9ddb30bab3d2b