### PR TITLE
Show persisted token logs on load

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -205,6 +205,11 @@ Object.assign(document.body.style, {
     return res;
   };
 
+  // render persisted log immediately if entries exist
+  if (simulation.tokenLogStream.get().length) {
+    tokenPanel.show();
+  }
+
   const origStart = simulation.start;
   simulation.start = (...args) => {
     tokenPanel.show();
@@ -217,11 +222,13 @@ Object.assign(document.body.style, {
     return res;
   };
 
-    simulation.tokenLogStream.subscribe(entries => {
-      if (entries.length) {
-        tokenPanel.show();
-      }
-    });
+  simulation.tokenLogStream.subscribe(entries => {
+    if (entries.length) {
+      tokenPanel.show();
+    } else {
+      tokenPanel.hide();
+    }
+  });
 
   window.diagramTree.onSelect = id => {
     const element = elementRegistry.get(id);


### PR DESCRIPTION
## Summary
- Display token log panel when saved entries exist
- Hide token log panel again if log becomes empty

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9f71e06208328ba60c26a8d717959