### PR TITLE
feat: export blockchain log after simulation

### DIFF
--- a/public/js/components/tokenListPanel.js
+++ b/public/js/components/tokenListPanel.js
@@ -42,6 +42,22 @@
     });
     panel.appendChild(closeBtn);
 
+    const downloadBtn = document.createElement('button');
+    downloadBtn.textContent = '\u2193';
+    Object.assign(downloadBtn.style, {
+      position: 'absolute',
+      top: '0.25rem',
+      right: '1.75rem',
+      background: 'transparent',
+      border: 'none',
+      color: 'inherit',
+      cursor: 'pointer',
+      fontSize: '1rem',
+      lineHeight: '1',
+      display: 'none'
+    });
+    panel.appendChild(downloadBtn);
+
     function render(entries){
       list.innerHTML = '';
       entries.forEach(entry => {
@@ -97,13 +113,22 @@
 
     function hide(){
       panel.style.display = 'none';
+      downloadBtn.style.display = 'none';
+    }
+
+    function showDownload(){
+      downloadBtn.style.display = 'inline';
+    }
+
+    function setDownloadHandler(handler){
+      downloadBtn.addEventListener('click', handler);
     }
 
     closeBtn.addEventListener('click', hide);
 
     observeDOMRemoval(panel, ...cleanupFns);
 
-    return { el: panel, show, hide };
+    return { el: panel, show, hide, showDownload, setDownloadHandler };
   }
 
   global.tokenListPanel = { createTokenListPanel };


### PR DESCRIPTION
## Summary
- add hidden download button to token panel and expose API for handler
- serialize `blockchain.chain` to JSON for download when simulation completes
- show download button when token stream empties

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa2ff428008328858e55fd7aa60de0