### PR TITLE
refactor: move token list styles to css classes

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -151,3 +151,41 @@
   line-height: 1;
   cursor: pointer;
 }
+
+/* Token list panel and entries */
+.token-list-panel {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  width: 250px;
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 1.5rem 0.5rem 0.5rem 0.5rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  display: none;
+  z-index: 1000;
+  font-size: 14px;
+}
+
+.token-list-entry {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.token-list-download {
+  position: absolute;
+  top: 0.25rem;
+  right: 1.75rem;
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  display: none;
+}

--- a/public/js/components/tokenListPanel.js
+++ b/public/js/components/tokenListPanel.js
@@ -1,61 +1,20 @@
 (function(global){
   function createTokenListPanel(logStream, themeStream = currentTheme){
     const panel = document.createElement('div');
-    Object.assign(panel.style, {
-      position: 'fixed',
-      bottom: '1rem',
-      right: '1rem',
-      width: '250px',
-      maxHeight: '200px',
-      overflowY: 'auto',
-      padding: '1.5rem 0.5rem 0.5rem 0.5rem',
-      borderRadius: '4px',
-      boxShadow: '0 2px 6px rgba(0,0,0,0.2)',
-      display: 'none',
-      zIndex: '1000',
-      fontSize: '14px'
-    });
+    panel.classList.add('token-list-panel');
 
     const list = document.createElement('ul');
-    Object.assign(list.style, {
-      listStyle: 'none',
-      margin: 0,
-      padding: 0,
-      display: 'flex',
-      flexDirection: 'column',
-      gap: '0.25rem'
-    });
+    list.classList.add('token-list-entry');
     panel.appendChild(list);
 
     const closeBtn = document.createElement('button');
     closeBtn.textContent = '\u00D7';
-    Object.assign(closeBtn.style, {
-      position: 'absolute',
-      top: '0.25rem',
-      right: '0.25rem',
-      background: 'transparent',
-      border: 'none',
-      color: 'inherit',
-      cursor: 'pointer',
-      fontSize: '1rem',
-      lineHeight: '1'
-    });
+    closeBtn.classList.add('addon-filter-close');
     panel.appendChild(closeBtn);
 
     const downloadBtn = document.createElement('button');
     downloadBtn.textContent = '\u2193';
-    Object.assign(downloadBtn.style, {
-      position: 'absolute',
-      top: '0.25rem',
-      right: '1.75rem',
-      background: 'transparent',
-      border: 'none',
-      color: 'inherit',
-      cursor: 'pointer',
-      fontSize: '1rem',
-      lineHeight: '1',
-      display: 'none'
-    });
+    downloadBtn.classList.add('token-list-download');
     panel.appendChild(downloadBtn);
 
     function render(entries){


### PR DESCRIPTION
## Summary
- move token list panel and entries styling into CSS classes
- apply classes in tokenListPanel instead of inline styles
- keep theme stream override support

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68aa38e3f9288328903b8f2b065aaeb2