### PR TITLE
Add header and clear button to token log panel

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -153,6 +153,7 @@
 }
 
 /* Token list panel and entries */
+
 .token-list-panel {
   position: fixed;
   bottom: 1rem;
@@ -160,12 +161,32 @@
   width: 250px;
   max-height: 200px;
   overflow-y: auto;
-  padding: 1.5rem 0.5rem 0.5rem 0.5rem;
+  padding: 0.5rem;
   border-radius: 4px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
   display: none;
   z-index: 1000;
   font-size: 14px;
+}
+
+.token-list-header {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.token-list-header span {
+  flex-grow: 1;
+}
+
+.token-list-header button {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
 }
 
 .token-list-entry {
@@ -178,14 +199,5 @@
 }
 
 .token-list-download {
-  position: absolute;
-  top: 0.25rem;
-  right: 1.75rem;
-  background: transparent;
-  border: none;
-  color: inherit;
-  cursor: pointer;
-  font-size: 1rem;
-  line-height: 1;
   display: none;
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -183,6 +183,7 @@ Object.assign(document.body.style, {
   const selectionService= modeler.get('selection');
   const canvas          = modeler.get('canvas');
   const simulation      = createSimulation({ elementRegistry, canvas });
+  window.simulation = simulation;
   const overlays        = modeler.get('overlays');
 
   // Token list panel for simulation log

--- a/public/js/components/tokenListPanel.js
+++ b/public/js/components/tokenListPanel.js
@@ -3,19 +3,32 @@
     const panel = document.createElement('div');
     panel.classList.add('token-list-panel');
 
-    const list = document.createElement('ul');
-    list.classList.add('token-list-entry');
-    panel.appendChild(list);
+    const header = document.createElement('div');
+    header.classList.add('token-list-header');
+    panel.appendChild(header);
 
-    const closeBtn = document.createElement('button');
-    closeBtn.textContent = '\u00D7';
-    closeBtn.classList.add('addon-filter-close');
-    panel.appendChild(closeBtn);
+    const title = document.createElement('span');
+    title.textContent = 'Token Log';
+    header.appendChild(title);
 
     const downloadBtn = document.createElement('button');
     downloadBtn.textContent = '\u2193';
     downloadBtn.classList.add('token-list-download');
-    panel.appendChild(downloadBtn);
+    header.appendChild(downloadBtn);
+
+    const clearBtn = document.createElement('button');
+    clearBtn.textContent = 'Clear';
+    clearBtn.classList.add('token-list-clear');
+    header.appendChild(clearBtn);
+
+    const closeBtn = document.createElement('button');
+    closeBtn.textContent = '\u00D7';
+    closeBtn.classList.add('token-list-close');
+    header.appendChild(closeBtn);
+
+    const list = document.createElement('ul');
+    list.classList.add('token-list-entry');
+    panel.appendChild(list);
 
     function render(entries){
       list.innerHTML = '';
@@ -83,6 +96,12 @@
       // allow consumers to hook into the download button
       downloadBtn.addEventListener('click', handler);
     }
+
+    clearBtn.addEventListener('click', () => {
+      if (global.simulation && typeof global.simulation.clearTokenLog === 'function') {
+        global.simulation.clearTokenLog();
+      }
+    });
 
     closeBtn.addEventListener('click', hide);
 


### PR DESCRIPTION
## Summary
- Wrap token log controls in a new header with title and buttons
- Add clear action that uses the simulation's `clearTokenLog`
- Style the token log header with flexbox and expose simulation globally

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aa39e18a3c8328bf6cccf1fa9ad057