### PR TITLE
Animate token list panel with class toggle

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -164,9 +164,20 @@
   padding: 0.5rem;
   border-radius: 4px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
-  display: none;
   z-index: 1000;
   font-size: 14px;
+  opacity: 0;
+  transform: translateY(1rem);
+  pointer-events: none;
+  visibility: hidden;
+  transition: opacity 0.3s, transform 0.3s;
+}
+
+.token-list-panel.token-list-open {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+  visibility: visible;
 }
 
 .token-list-header {

--- a/public/js/components/tokenListPanel.js
+++ b/public/js/components/tokenListPanel.js
@@ -2,6 +2,7 @@
   function createTokenListPanel(logStream, themeStream = currentTheme){
     const panel = document.createElement('div');
     panel.classList.add('token-list-panel');
+    panel.setAttribute('aria-hidden', 'true');
 
     const header = document.createElement('div');
     header.classList.add('token-list-header');
@@ -63,7 +64,7 @@
       });
       prevLength = entries.length;
       if(entries.length){
-        panel.style.display = 'block';
+        show();
         panel.scrollTop = panel.scrollHeight;
       }
     }
@@ -101,12 +102,14 @@
 
     function show(){
       if(list.children.length){
-        panel.style.display = 'block';
+        panel.classList.add('token-list-open');
+        panel.setAttribute('aria-hidden', 'false');
       }
     }
 
     function hide(){
-      panel.style.display = 'none';
+      panel.classList.remove('token-list-open');
+      panel.setAttribute('aria-hidden', 'true');
       downloadBtn.style.display = 'none';
     }
 


### PR DESCRIPTION
## Summary
- Animate token log panel with CSS transitions
- Toggle visibility via `token-list-open` class instead of inline `display`
- Ensure panel is removed from accessibility tree when hidden

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68aa3c43ab588328b197db22bf0e3771