### PR TITLE
Add search filter to token log panel

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -200,6 +200,14 @@
   line-height: 1;
 }
 
+.token-list-search {
+  width: 100%;
+  margin-bottom: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 2px;
+  box-sizing: border-box;
+}
+
 .token-list-entry {
   list-style: none;
   margin: 0;

--- a/public/js/components/tokenListPanel.js
+++ b/public/js/components/tokenListPanel.js
@@ -27,6 +27,12 @@
     closeBtn.classList.add('token-list-close');
     header.appendChild(closeBtn);
 
+    const searchInput = document.createElement('input');
+    searchInput.type = 'text';
+    searchInput.placeholder = 'Search';
+    searchInput.classList.add('token-list-search');
+    panel.appendChild(searchInput);
+
     const list = document.createElement('ul');
     list.classList.add('token-list-entry');
     panel.appendChild(list);
@@ -44,7 +50,12 @@
 
     function render(entries){
       list.innerHTML = '';
+      const query = searchInput.value.trim().toLowerCase();
+      const filtered = [];
       entries.forEach((entry, index) => {
+        const tokenId = entry.tokenId != null ? String(entry.tokenId).toLowerCase() : '';
+        const elementName = entry.elementName ? entry.elementName.toLowerCase() : '';
+        if(query && !(tokenId.includes(query) || elementName.includes(query))) return;
         const li = document.createElement('li');
         const time = new Date(entry.timestamp).toLocaleTimeString();
         const namePart = entry.elementName ? ` - ${entry.elementName}` : '';
@@ -52,7 +63,7 @@
         li.textContent = `${time} ${idPart}${entry.elementId}${namePart}`;
 
         li.classList.add('token-entry');
-        li.classList.add(index % 2 === 0 ? 'token-entry-even' : 'token-entry-odd');
+        li.classList.add(filtered.length % 2 === 0 ? 'token-entry-even' : 'token-entry-odd');
         const typeClass = getTypeClass(entry.elementId);
         if(typeClass) li.classList.add(typeClass);
         if(index >= prevLength){
@@ -61,15 +72,18 @@
         }
 
         list.appendChild(li);
+        filtered.push(entry);
       });
       prevLength = entries.length;
-      if(entries.length){
+      if(filtered.length){
         show();
         panel.scrollTop = panel.scrollHeight;
       }
     }
 
     const unsubscribe = logStream.subscribe(render);
+
+    searchInput.addEventListener('input', () => render(logStream.get()));
 
     const cleanupFns = [unsubscribe];
 
@@ -98,6 +112,10 @@
       panel.style.color = theme.colors.foreground;
       panel.style.border = `1px solid ${theme.colors.border}`;
       panel.style.fontFamily = theme.fonts.base || 'sans-serif';
+      searchInput.style.background = theme.colors.surface;
+      searchInput.style.color = theme.colors.foreground;
+      searchInput.style.border = `1px solid ${theme.colors.border}`;
+      searchInput.style.fontFamily = theme.fonts.base || 'sans-serif';
     });
 
     function show(){


### PR DESCRIPTION
## Summary
- Add search input to token log panel and filter entries by token ID or element name
- Apply theme styling to search field and expose basic layout styles in CSS

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa3d48421483288b2b7d8909bce4fc