### PR TITLE
Expose diagram tree toggle in toolbar

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -108,16 +108,6 @@
   padding: 1rem;
 }
 
-.diagram-tree-toggle {
-  position: fixed;
-  bottom: 3rem;
-  right: 1rem;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  cursor: pointer;
-  z-index: 1001;
-}
-
 .diagram-tree-close {
   position: absolute;
   top: 0.25rem;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -191,7 +191,7 @@ Object.assign(document.body.style, {
     .createTokenListPanel(simulation.tokenLogStream, currentTheme);
   document.body.appendChild(tokenPanel.el);
 
-  const treeBtn = document.querySelector('.diagram-tree-toggle');
+  let treeBtn;
 
   const origPanelShow = tokenPanel.show;
   tokenPanel.show = (...args) => {
@@ -1048,6 +1048,8 @@ function rebuildMenu() {
   ];
 
   controls.push(saveBtn);
+  treeBtn = reactiveButton(new Stream("🌳"), () => window.diagramTree.togglePanel(), { outline: true, title: "Toggle diagram tree" });
+  controls.push(treeBtn);
   controls.push(themedThemeSelector());
 
   const controlsBar = row(controls, {
@@ -1066,9 +1068,8 @@ function rebuildMenu() {
 
   // insert the controls bar before the canvas
   document.body.insertBefore(controlsBar, canvasEl);
+  if (tokenPanel.setTreeButton) tokenPanel.setTreeButton(treeBtn);
 
-  
-  
   // 6) Wire up double-click on any BPMN element
   eventBus.on('element.dblclick', ({ element }) => {
     if (element.type && element.type.startsWith('bpmn:')) {

--- a/public/js/components/layout.js
+++ b/public/js/components/layout.js
@@ -133,15 +133,10 @@ window.addEventListener('DOMContentLoaded', () => {
   panel.appendChild(content);
   document.body.appendChild(panel);
 
-  const btn = document.createElement('button');
-  btn.textContent = 'Tree';
-  btn.classList.add('diagram-tree-toggle');
-  btn.addEventListener('click', () => {
+  window.diagramTree.togglePanel = () => {
     const open = panel.style.left === '0px';
     panel.style.left = open ? '-300px' : '0px';
-  });
-
-  document.body.appendChild(btn);
+  };
 
   // Apply theme styling
   currentTheme.subscribe(theme => {
@@ -149,10 +144,6 @@ window.addEventListener('DOMContentLoaded', () => {
     panel.style.background = colors.surface;
     panel.style.color = colors.foreground;
     panel.style.boxShadow = `2px 0 6px ${colors.border}`;
-
-    btn.style.backgroundColor = colors.primary;
-    btn.style.color = colors.foreground;
-    btn.style.border = `1px solid ${colors.border}`;
 
     closeBtn.style.background = 'transparent';
     closeBtn.style.color = colors.foreground;

--- a/public/js/components/tokenListPanel.js
+++ b/public/js/components/tokenListPanel.js
@@ -87,8 +87,8 @@
 
     const cleanupFns = [unsubscribe];
 
-    const treeBtn = document.querySelector('.diagram-tree-toggle');
-    if(treeBtn){
+    function setTreeButton(treeBtn){
+      if(!treeBtn) return;
       const styles = window.getComputedStyle(treeBtn);
       const gap = 8; // px
 
@@ -150,7 +150,7 @@
 
     observeDOMRemoval(panel, ...cleanupFns);
 
-    return { el: panel, show, hide, showDownload, setDownloadHandler };
+    return { el: panel, show, hide, showDownload, setDownloadHandler, setTreeButton };
   }
 
   global.tokenListPanel = { createTokenListPanel };


### PR DESCRIPTION
## Summary
- Replace floating diagram tree button with `window.diagramTree.togglePanel()` hook
- Add tree toggle button to toolbar and wire token log panel to hide it when open
- Remove obsolete diagram tree toggle CSS and accept external tree button reference in token panel

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aa3f44395483288e3f5ae82b1ed139