### PR TITLE
Place simulation list at bottom right

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1068,7 +1068,6 @@ function rebuildMenu() {
 
   // insert the controls bar before the canvas
   document.body.insertBefore(controlsBar, canvasEl);
-  if (tokenPanel.setTreeButton) tokenPanel.setTreeButton(treeBtn);
 
   // 6) Wire up double-click on any BPMN element
   eventBus.on('element.dblclick', ({ element }) => {


### PR DESCRIPTION
## Summary
- Let token log panel use default bottom-right placement by dropping tree button positioning

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Missing script "build")

------
https://chatgpt.com/codex/tasks/task_e_68aa4132af008328977b1a7d8a1749c6