### PR TITLE
Add help panel for BPMN element guidance

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,3 +1,5 @@
+import { createHelpPanel } from './components/helpPanel.js';
+
 // js/app.js
   const typeIcons = {
     'Knowledge': '📚',
@@ -191,6 +193,9 @@ Object.assign(document.body.style, {
     .createTokenListPanel(simulation.tokenLogStream, currentTheme);
   document.body.appendChild(tokenPanel.el);
 
+  const helpPanel = createHelpPanel();
+  document.body.appendChild(helpPanel.el);
+
   let treeBtn;
 
   const origPanelShow = tokenPanel.show;
@@ -279,6 +284,7 @@ Object.assign(document.body.style, {
   eventBus.on('selection.changed', ({ newSelection }) => {
     const element = newSelection[0];
     window.diagramTree.setSelectedId(element?.id || null);
+    helpPanel.update(element);
   });
 
   function updateDiagramTree() {

--- a/public/js/components/helpPanel.js
+++ b/public/js/components/helpPanel.js
@@ -1,0 +1,33 @@
+import { helpContent } from '../helpContent.js';
+
+export function createHelpPanel() {
+  const panel = document.createElement('aside');
+  panel.className = 'help-panel';
+  panel.style.position = 'fixed';
+  panel.style.top = '0';
+  panel.style.right = '0';
+  panel.style.height = '100%';
+  panel.style.width = '250px';
+  panel.style.overflowY = 'auto';
+  panel.style.background = '#fff';
+  panel.style.borderLeft = '1px solid #ccc';
+  panel.style.padding = '1em';
+  panel.style.display = 'none';
+
+  const content = document.createElement('div');
+  panel.appendChild(content);
+
+  function update(element) {
+    const type = element?.businessObject?.$type;
+    const help = type && helpContent[type];
+    if (help) {
+      content.innerHTML = help;
+      panel.style.display = '';
+    } else {
+      panel.style.display = 'none';
+      content.innerHTML = '';
+    }
+  }
+
+  return { el: panel, update };
+}

--- a/public/js/helpContent.js
+++ b/public/js/helpContent.js
@@ -1,0 +1,5 @@
+export const helpContent = {
+  'bpmn:StartEvent': '<p>Marks the entry point of the process.</p>',
+  'bpmn:Task': '<p>Represents a unit of work performed within the process.</p>',
+  'bpmn:EndEvent': '<p>Indicates where the process ends.</p>'
+};


### PR DESCRIPTION
## Summary
- add reusable help panel component that renders BPMN guidance using element `$type`
- maintain help text registry for BPMN types
- wire help panel into app and update on selection change

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac7ab6af3883288a0394ec708edb0a