### PR TITLE
feat: design help panel and add quick menu instructions

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -252,3 +252,31 @@
 .token-list-download {
   display: none;
 }
+
+/* Help panel */
+.help-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 250px;
+  overflow-y: auto;
+  background: #fff;
+  border-left: 1px solid #ccc;
+  box-shadow: -2px 0 6px rgba(0,0,0,0.1);
+  padding: 1rem;
+  z-index: 1500;
+  display: none;
+}
+
+.help-panel h2 {
+  margin-top: 0;
+  font-size: 1.1rem;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.help-panel .help-item {
+  margin-bottom: 0.5rem;
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -187,6 +187,7 @@ Object.assign(document.body.style, {
   const simulation      = createSimulation({ elementRegistry, canvas });
   window.simulation = simulation;
   const overlays        = modeler.get('overlays');
+  const contextPad      = modeler.get('contextPad');
 
   // Token list panel for simulation log
   const tokenPanel = window.tokenListPanel
@@ -284,6 +285,19 @@ Object.assign(document.body.style, {
   eventBus.on('selection.changed', ({ newSelection }) => {
     const element = newSelection[0];
     window.diagramTree.setSelectedId(element?.id || null);
+    helpPanel.update(element);
+  });
+
+  eventBus.on('contextPad.open', ({ element }) => {
+    const entries = contextPad.getEntries(element);
+    const types = Object.values(entries)
+      .map(entry => entry.action?.options?.type)
+      .filter(Boolean);
+    helpPanel.showQuickMenuHelp(types);
+  });
+
+  eventBus.on('contextPad.close', () => {
+    const [element] = selectionService.get();
     helpPanel.update(element);
   });
 

--- a/public/js/components/helpPanel.js
+++ b/public/js/components/helpPanel.js
@@ -3,16 +3,11 @@ import { helpContent } from '../helpContent.js';
 export function createHelpPanel() {
   const panel = document.createElement('aside');
   panel.className = 'help-panel';
-  panel.style.position = 'fixed';
-  panel.style.top = '0';
-  panel.style.right = '0';
-  panel.style.height = '100%';
-  panel.style.width = '250px';
-  panel.style.overflowY = 'auto';
-  panel.style.background = '#fff';
-  panel.style.borderLeft = '1px solid #ccc';
-  panel.style.padding = '1em';
   panel.style.display = 'none';
+
+  const header = document.createElement('h2');
+  header.textContent = 'Help';
+  panel.appendChild(header);
 
   const content = document.createElement('div');
   panel.appendChild(content);
@@ -29,5 +24,18 @@ export function createHelpPanel() {
     }
   }
 
-  return { el: panel, update };
+  function showQuickMenuHelp(types = []) {
+    const items = types
+      .map(t => helpContent[t] && `<div class="help-item"><strong>${t.replace('bpmn:', '')}</strong>: ${helpContent[t]}</div>`)
+      .filter(Boolean);
+    if (items.length) {
+      content.innerHTML = items.join('');
+      panel.style.display = '';
+    } else {
+      panel.style.display = 'none';
+      content.innerHTML = '';
+    }
+  }
+
+  return { el: panel, update, showQuickMenuHelp };
 }

--- a/public/js/helpContent.js
+++ b/public/js/helpContent.js
@@ -1,5 +1,8 @@
 export const helpContent = {
   'bpmn:StartEvent': '<p>Marks the entry point of the process.</p>',
   'bpmn:Task': '<p>Represents a unit of work performed within the process.</p>',
-  'bpmn:EndEvent': '<p>Indicates where the process ends.</p>'
+  'bpmn:EndEvent': '<p>Indicates where the process ends.</p>',
+  'bpmn:ExclusiveGateway': '<p>Routes the flow into one of several paths based on conditions.</p>',
+  'bpmn:ParallelGateway': '<p>Splits and joins paths to run activities concurrently.</p>',
+  'bpmn:TextAnnotation': '<p>Provides additional documentation or notes for elements.</p>'
 };


### PR DESCRIPTION
## Summary
- Style help panel with header, shadow and high z-index so it stays on top
- Display element instructions when quick menu opens using new showQuickMenuHelp
- Expand help content for gateway and annotation elements

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68ac8158e1508328b7c855c42c2ec3b6