### PR TITLE
feat: raise help panel z-index

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -265,7 +265,7 @@
   border-left: 1px solid #ccc;
   box-shadow: -2px 0 6px rgba(0,0,0,0.1);
   padding: 1rem;
-  z-index: 1500;
+  z-index: 3000;
   display: none;
 }
 


### PR DESCRIPTION
## Summary
- ensure help panel overlays other side panels by raising its z-index to 3000

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_68ac8544f6b08328add7d8c6f887bf0b