### PR TITLE
Guard contextPad handler against missing elements

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -289,6 +289,11 @@ Object.assign(document.body.style, {
   });
 
   eventBus.on('contextPad.open', ({ element }) => {
+    if (!element) {
+      console.warn('contextPad.open called without element');
+      return;
+    }
+
     const entries = contextPad.getEntries(element);
     const types = Object.values(entries)
       .map(entry => entry.action?.options?.type)


### PR DESCRIPTION
## Summary
- prevent `contextPad.open` handler from crashing when no element is supplied
- show quick-menu help only when a valid element is present

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac8745854c8328bdf396df7eb79707