### PR TITLE
feat: limit replace menu to start events

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,4 +1,5 @@
 import { createHelpPanel } from './components/helpPanel.js';
+import customReplaceModule from './modules/customReplaceMenuProvider.js';
 
 // js/app.js
   const typeIcons = {
@@ -150,7 +151,7 @@ Object.assign(document.body.style, {
   // ─── instantiate modeler with navigator only ───────────────────────────────
   const navModule = window.navigatorModule || window.bpmnNavigator;
 
-  const additionalModules = [];
+  const additionalModules = [ customReplaceModule ];
   if (navModule) additionalModules.push(navModule);
 
 

--- a/public/js/modules/customReplaceMenuProvider.js
+++ b/public/js/modules/customReplaceMenuProvider.js
@@ -1,0 +1,51 @@
+import inherits from 'inherits';
+import ReplaceMenuProvider from 'bpmn-js/lib/features/popup-menu/ReplaceMenuProvider';
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+import * as replaceOptions from 'bpmn-js/lib/features/replace/ReplaceOptions';
+
+import { START_EVENT as CUSTOM_START_EVENT } from './startEventReplaceOptions';
+
+export function CustomReplaceMenuProvider(
+  bpmnFactory,
+  popupMenu,
+  modeling,
+  moddle,
+  bpmnReplace,
+  rules,
+  translate,
+  moddleCopy
+) {
+  ReplaceMenuProvider.call(this,
+    bpmnFactory,
+    popupMenu,
+    modeling,
+    moddle,
+    bpmnReplace,
+    rules,
+    translate,
+    moddleCopy
+  );
+}
+
+CustomReplaceMenuProvider.$inject = ReplaceMenuProvider.$inject;
+
+inherits(CustomReplaceMenuProvider, ReplaceMenuProvider);
+
+CustomReplaceMenuProvider.prototype.getPopupMenuEntries = function(target) {
+  const businessObject = target.businessObject;
+
+  if (is(businessObject, 'bpmn:StartEvent') && !is(businessObject.$parent, 'bpmn:SubProcess')) {
+    const originalStart = replaceOptions.START_EVENT;
+    replaceOptions.START_EVENT = CUSTOM_START_EVENT;
+    const entries = ReplaceMenuProvider.prototype.getPopupMenuEntries.call(this, target);
+    replaceOptions.START_EVENT = originalStart;
+    return entries;
+  }
+
+  return ReplaceMenuProvider.prototype.getPopupMenuEntries.call(this, target);
+};
+
+export default {
+  __init__: ['replaceMenuProvider'],
+  replaceMenuProvider: ['type', CustomReplaceMenuProvider]
+};

--- a/public/js/modules/startEventReplaceOptions.js
+++ b/public/js/modules/startEventReplaceOptions.js
@@ -1,0 +1,9 @@
+import { START_EVENT as DEFAULT_START_EVENT } from 'bpmn-js/lib/features/replace/ReplaceOptions';
+
+// Filter out intermediate throw and end event targets, keeping only start event variations
+export const START_EVENT = DEFAULT_START_EVENT.filter(option => {
+  const targetType = option?.target?.type;
+  return targetType !== 'bpmn:IntermediateThrowEvent' && targetType !== 'bpmn:EndEvent';
+});
+
+export default START_EVENT;


### PR DESCRIPTION
## Summary
- add custom START_EVENT options without intermediate or end events
- override ReplaceMenuProvider to use filtered start events
- register module so replace menu only shows start-event variants

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac8cb57b7c832892c8b88adc883dc6