### PR TITLE
refactor: convert replace menu provider to class

### DIFF
--- a/public/js/modules/customReplaceMenuProvider.js
+++ b/public/js/modules/customReplaceMenuProvider.js
@@ -1,21 +1,11 @@
-import inherits from 'inherits';
 import ReplaceMenuProvider from 'bpmn-js/lib/features/popup-menu/ReplaceMenuProvider';
 import { is } from 'bpmn-js/lib/util/ModelUtil';
 import * as replaceOptions from 'bpmn-js/lib/features/replace/ReplaceOptions';
 
 import { START_EVENT as CUSTOM_START_EVENT } from './startEventReplaceOptions';
 
-export function CustomReplaceMenuProvider(
-  bpmnFactory,
-  popupMenu,
-  modeling,
-  moddle,
-  bpmnReplace,
-  rules,
-  translate,
-  moddleCopy
-) {
-  ReplaceMenuProvider.call(this,
+export class CustomReplaceMenuProvider extends ReplaceMenuProvider {
+  constructor(
     bpmnFactory,
     popupMenu,
     modeling,
@@ -24,26 +14,35 @@ export function CustomReplaceMenuProvider(
     rules,
     translate,
     moddleCopy
-  );
+  ) {
+    super(
+      bpmnFactory,
+      popupMenu,
+      modeling,
+      moddle,
+      bpmnReplace,
+      rules,
+      translate,
+      moddleCopy
+    );
+  }
+
+  getPopupMenuEntries(target) {
+    const businessObject = target.businessObject;
+
+    if (is(businessObject, 'bpmn:StartEvent') && !is(businessObject.$parent, 'bpmn:SubProcess')) {
+      const originalStart = replaceOptions.START_EVENT;
+      replaceOptions.START_EVENT = CUSTOM_START_EVENT;
+      const entries = super.getPopupMenuEntries(target);
+      replaceOptions.START_EVENT = originalStart;
+      return entries;
+    }
+
+    return super.getPopupMenuEntries(target);
+  }
 }
 
 CustomReplaceMenuProvider.$inject = ReplaceMenuProvider.$inject;
-
-inherits(CustomReplaceMenuProvider, ReplaceMenuProvider);
-
-CustomReplaceMenuProvider.prototype.getPopupMenuEntries = function(target) {
-  const businessObject = target.businessObject;
-
-  if (is(businessObject, 'bpmn:StartEvent') && !is(businessObject.$parent, 'bpmn:SubProcess')) {
-    const originalStart = replaceOptions.START_EVENT;
-    replaceOptions.START_EVENT = CUSTOM_START_EVENT;
-    const entries = ReplaceMenuProvider.prototype.getPopupMenuEntries.call(this, target);
-    replaceOptions.START_EVENT = originalStart;
-    return entries;
-  }
-
-  return ReplaceMenuProvider.prototype.getPopupMenuEntries.call(this, target);
-};
 
 export default {
   __init__: ['replaceMenuProvider'],


### PR DESCRIPTION
## Summary
- refactor custom replace menu provider to use ES6 class instead of inherits

## Testing
- `npm test` *(fails: Missing script "test")*
- `python3 -m http.server 8080 --directory public` *(served app, console verification not possible in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8e20b27483289231beaf83df1fda