### PR TITLE
Add import map and fix module paths for bpmn-js

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -181,6 +181,13 @@
   <script src="js/firebase.js"></script>
   <script src="js/login.js"></script>
   <script src="js/addOnStore.js"></script>
+  <script type="importmap">
+  {
+    "imports": {
+      "bpmn-js/": "https://unpkg.com/bpmn-js@18.6.2/"
+    }
+  }
+  </script>
   <script type="module" src="js/app.js"></script>
   <script src="js/h1-check.js"></script>
   <script src="js/palette-toggle.js"></script>

--- a/public/js/modules/customReplaceMenuProvider.js
+++ b/public/js/modules/customReplaceMenuProvider.js
@@ -1,8 +1,8 @@
-import ReplaceMenuProvider from 'bpmn-js/lib/features/popup-menu/ReplaceMenuProvider';
-import { is } from 'bpmn-js/lib/util/ModelUtil';
-import * as replaceOptions from 'bpmn-js/lib/features/replace/ReplaceOptions';
+import ReplaceMenuProvider from 'bpmn-js/lib/features/popup-menu/ReplaceMenuProvider.js';
+import { is } from 'bpmn-js/lib/util/ModelUtil.js';
+import * as replaceOptions from 'bpmn-js/lib/features/replace/ReplaceOptions.js';
 
-import { START_EVENT as CUSTOM_START_EVENT } from './startEventReplaceOptions';
+import { START_EVENT as CUSTOM_START_EVENT } from './startEventReplaceOptions.js';
 
 export class CustomReplaceMenuProvider extends ReplaceMenuProvider {
   constructor(

--- a/public/js/modules/startEventReplaceOptions.js
+++ b/public/js/modules/startEventReplaceOptions.js
@@ -1,4 +1,4 @@
-import { START_EVENT as DEFAULT_START_EVENT } from 'bpmn-js/lib/features/replace/ReplaceOptions';
+import { START_EVENT as DEFAULT_START_EVENT } from 'bpmn-js/lib/features/replace/ReplaceOptions.js';
 
 // Filter out intermediate throw and end event targets, keeping only start event variations
 export const START_EVENT = DEFAULT_START_EVENT.filter(option => {


### PR DESCRIPTION
## Summary
- add import map for bpmn-js in index.html
- append .js extensions to bpmn-js module imports
- adjust start event replace options module

## Testing
- `curl -sI http://localhost:8000/public/index.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68ac915196c88328b4b5aca6c0b96ad7