### PR TITLE
chore: add import maps for bpmn-js esm deps

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -184,7 +184,24 @@
   <script type="importmap">
   {
     "imports": {
-      "bpmn-js/": "https://unpkg.com/bpmn-js@18.6.2/"
+      "bpmn-js/": "https://unpkg.com/bpmn-js@18.6.2/",
+      "diagram-js/": "https://unpkg.com/diagram-js@15.3.0/",
+      "diagram-js-direct-editing/": "https://unpkg.com/diagram-js-direct-editing@3.2.0/",
+      "bpmn-moddle": "https://unpkg.com/bpmn-moddle@9.0.2/dist/index.js",
+      "moddle": "https://unpkg.com/moddle@7.2.0/dist/index.js",
+      "moddle-xml": "https://unpkg.com/moddle-xml@11.0.0/dist/index.js",
+      "saxen": "https://unpkg.com/saxen@10.0.0/dist/index.js",
+      "min-dash": "https://unpkg.com/min-dash@4.2.3/dist/index.esm.js",
+      "min-dom": "https://unpkg.com/min-dom@4.2.1/dist/index.esm.js",
+      "tiny-svg": "https://unpkg.com/tiny-svg@3.1.3/dist/index.esm.js",
+      "inherits-browser": "https://unpkg.com/inherits-browser@0.1.0/dist/index.es.js",
+      "object-refs": "https://unpkg.com/object-refs@0.4.0/dist/index.js",
+      "path-intersection": "https://unpkg.com/path-intersection@3.1.0/intersect.js",
+      "didi": "https://unpkg.com/didi@10.2.2/dist/index.js",
+      "clsx": "https://unpkg.com/clsx@2.1.1/dist/clsx.mjs",
+      "@bpmn-io/diagram-js-ui/": "https://unpkg.com/@bpmn-io/diagram-js-ui@0.2.3/lib/",
+      "htm": "https://unpkg.com/htm@3.1.1/dist/htm.module.js",
+      "preact": "https://unpkg.com/preact@10.26.9/dist/preact.module.js"
     }
   }
   </script>


### PR DESCRIPTION
## Summary
- add import-map entries for bpmn-js and its dependencies such as min-dash, min-dom, tiny-svg, moddle, and others

## Testing
- `python3 -m http.server 8000 --directory public` (served `index.html` for manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68ac93c4987c8328871281b683ca711d