### PR TITLE
Simplify start event replacement menu

### DIFF
--- a/public/js/modules/customReplaceMenuProvider.js
+++ b/public/js/modules/customReplaceMenuProvider.js
@@ -1,8 +1,5 @@
 import ReplaceMenuProvider from 'bpmn-js/lib/features/popup-menu/ReplaceMenuProvider.js';
 import { is } from 'bpmn-js/lib/util/ModelUtil.js';
-import * as replaceOptions from 'bpmn-js/lib/features/replace/ReplaceOptions.js';
-
-import { START_EVENT as CUSTOM_START_EVENT } from './startEventReplaceOptions.js';
 
 export class CustomReplaceMenuProvider extends ReplaceMenuProvider {
   constructor(
@@ -29,16 +26,14 @@ export class CustomReplaceMenuProvider extends ReplaceMenuProvider {
 
   getPopupMenuEntries(target) {
     const businessObject = target.businessObject;
+    const entries = super.getPopupMenuEntries(target);
 
     if (is(businessObject, 'bpmn:StartEvent') && !is(businessObject.$parent, 'bpmn:SubProcess')) {
-      const originalStart = replaceOptions.START_EVENT;
-      replaceOptions.START_EVENT = CUSTOM_START_EVENT;
-      const entries = super.getPopupMenuEntries(target);
-      replaceOptions.START_EVENT = originalStart;
-      return entries;
+      delete entries['replace-with-none-intermediate-throwing'];
+      delete entries['replace-with-none-end'];
     }
 
-    return super.getPopupMenuEntries(target);
+    return entries;
   }
 }
 

--- a/public/js/modules/startEventReplaceOptions.js
+++ b/public/js/modules/startEventReplaceOptions.js
@@ -1,9 +1,0 @@
-import { START_EVENT as DEFAULT_START_EVENT } from 'bpmn-js/lib/features/replace/ReplaceOptions.js';
-
-// Filter out intermediate throw and end event targets, keeping only start event variations
-export const START_EVENT = DEFAULT_START_EVENT.filter(option => {
-  const targetType = option?.target?.type;
-  return targetType !== 'bpmn:IntermediateThrowEvent' && targetType !== 'bpmn:EndEvent';
-});
-
-export default START_EVENT;


### PR DESCRIPTION
## Summary
- fetch replace menu entries via superclass and prune unsupported start-event actions
- remove custom start-event replace options module

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ac966b73d08328bd1c66fab0f22d50