### PR TITLE
Handle missing element in contextPad.open

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -289,9 +289,9 @@ Object.assign(document.body.style, {
     helpPanel.update(element);
   });
 
-  eventBus.on('contextPad.open', ({ element }) => {
+  eventBus.on('contextPad.open', (event) => {
+    const element = event.current?.target;
     if (!element) {
-      console.warn('contextPad.open called without element');
       return;
     }
 


### PR DESCRIPTION
## Summary
- Use full event object for `contextPad.open`
- Safely derive context pad element and remove startup warning

## Testing
- `npm test` *(fails: missing script)*
- `python3 -m http.server 8000 --directory public`

------
https://chatgpt.com/codex/tasks/task_e_68ac97e107108328b9fbb0e16675a279