### PR TITLE
fix: guard context pad open handler

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -290,12 +290,11 @@ Object.assign(document.body.style, {
   });
 
   eventBus.on('contextPad.open', (event) => {
-    const element = event.current?.target;
-    if (!element) {
-      return;
-    }
+    const { current } = event || {};
+    const element = current && current.target;
+    if (!element) return;
 
-    const entries = contextPad.getEntries(element);
+    const entries = current.entries || contextPad.getEntries(element);
     const types = Object.values(entries)
       .map(entry => entry.action?.options?.type)
       .filter(Boolean);


### PR DESCRIPTION
## Summary
- guard contextPad open event handler to skip when no element exists and reuse existing entries

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Missing script "build")*


------
https://chatgpt.com/codex/tasks/task_e_68ac99cac8e88328bd89355d8611f69f