### PR TITLE
Ensure help panel uses explicit display

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -266,7 +266,6 @@
   box-shadow: -2px 0 6px rgba(0,0,0,0.1);
   padding: 1rem;
   z-index: 3000;
-  display: none;
 }
 
 .help-panel h2 {

--- a/public/js/components/helpPanel.js
+++ b/public/js/components/helpPanel.js
@@ -17,7 +17,7 @@ export function createHelpPanel() {
     const help = type && helpContent[type];
     if (help) {
       content.innerHTML = help;
-      panel.style.display = '';
+      panel.style.display = 'block';
     } else {
       panel.style.display = 'none';
       content.innerHTML = '';
@@ -30,7 +30,7 @@ export function createHelpPanel() {
       .filter(Boolean);
     if (items.length) {
       content.innerHTML = items.join('');
-      panel.style.display = '';
+      panel.style.display = 'block';
     } else {
       panel.style.display = 'none';
       content.innerHTML = '';


### PR DESCRIPTION
## Summary
- remove default `display: none` from help panel CSS so it inherits block layout
- explicitly set help panel `display: 'block'` when showing to override default styles

## Testing
- `node --input-type=module` test script exercising `createHelpPanel()` logic
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac9b8135b883289490885168f89232