### PR TITLE
Load external quick help guide with theming

### DIFF
--- a/public/help/quick-help.html
+++ b/public/help/quick-help.html
@@ -1,0 +1,99 @@
+<style>
+:root {
+  color-scheme: light dark;
+}
+body {
+  background: var(--bg);
+  color: var(--text);
+  margin: 0;
+  font-family: sans-serif;
+}
+#help-container {
+  background: var(--panel);
+  padding: 1rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+#help-search {
+  width: 100%;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  background: var(--panel2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+#help-tags { margin-bottom: 0.5rem; }
+.tag {
+  display: inline-block;
+  margin: 0 0.25rem 0.25rem 0;
+  padding: 0.1rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  background: var(--panel2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  font-size: 0.8rem;
+}
+.tag.active {
+  background: var(--accent);
+  color: var(--text);
+}
+section { margin-bottom: 1rem; }
+section h2 {
+  margin: 0 0 0.5rem 0;
+  color: var(--accent);
+}
+</style>
+<div id="help-container">
+  <input id="help-search" type="search" placeholder="Search help..." />
+  <div id="help-tags"></div>
+  <div id="help-sections">
+    <section data-tags="getting started basics">
+      <h2>Getting Started</h2>
+      <p>Use the toolbar buttons to manipulate the diagram. Zoom with the ➕ and ➖ controls and use the tree view to navigate elements.</p>
+    </section>
+    <section data-tags="editing">
+      <h2>Editing</h2>
+      <p>Double‑click an element to edit its properties. Drag elements to reposition them. Use the palette to create new nodes.</p>
+    </section>
+    <section data-tags="simulation run">
+      <h2>Simulation</h2>
+      <p>Start the token simulation with the ▶ control. Pause with ⏸ or step through tokens using ⏭.</p>
+    </section>
+  </div>
+</div>
+<script>
+(function(){
+  const sections = Array.from(document.querySelectorAll('#help-sections section'));
+  const searchInput = document.getElementById('help-search');
+  const tagsContainer = document.getElementById('help-tags');
+  const tags = Array.from(new Set(sections.flatMap(s => (s.dataset.tags || '').split(/\s+/).filter(Boolean)))).sort();
+  let activeTag = '';
+  function filter(){
+    const q = searchInput.value.toLowerCase();
+    sections.forEach(s => {
+      const matchQuery = s.textContent.toLowerCase().includes(q);
+      const matchTag = !activeTag || (s.dataset.tags || '').split(/\s+/).includes(activeTag);
+      s.style.display = matchQuery && matchTag ? '' : 'none';
+    });
+  }
+  tags.forEach(tag => {
+    const btn = document.createElement('button');
+    btn.textContent = tag;
+    btn.className = 'tag';
+    btn.addEventListener('click', () => {
+      activeTag = activeTag === tag ? '' : tag;
+      Array.from(tagsContainer.children).forEach(c => c.classList.toggle('active', c===btn && activeTag));
+      filter();
+    });
+    tagsContainer.appendChild(btn);
+  });
+  searchInput.addEventListener('input', filter);
+  if (location.hash){
+    const tag = location.hash.slice(1);
+    const btn = Array.from(tagsContainer.children).find(b => b.textContent === tag);
+    if (btn) btn.click();
+  }
+})();
+</script>

--- a/public/js/components/helpGuide.js
+++ b/public/js/components/helpGuide.js
@@ -1,25 +1,4 @@
 (function(global){
-  // Simple help guide data; in practice this could be imported from HTML.
-  const HELP = [
-    {
-      title: 'Getting Started',
-      html: `
-        <p>Use the toolbar buttons to manipulate the diagram. Zoom with the ➕ and ➖ controls and use the tree view to navigate elements.</p>
-      `
-    },
-    {
-      title: 'Editing',
-      html: `
-        <p>Double‑click an element to edit its properties. Drag elements to reposition them. Use the palette to create new nodes.</p>
-      `
-    },
-    {
-      title: 'Simulation',
-      html: `
-        <p>Start the token simulation with the ▶ control. Pause with ⏸ or step through tokens using ⏭.</p>
-      `
-    }
-  ];
 
   function hexToRgb(hex){
     const m = /^#?([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(hex);
@@ -88,18 +67,23 @@
     const content = document.createElement('div');
     panel.appendChild(content);
 
-    HELP.forEach(section => {
-      const h2 = document.createElement('h2');
-      h2.textContent = section.title;
-      h2.style.color = 'var(--accent)';
-      h2.style.marginTop = '1rem';
-      content.appendChild(h2);
-
-      const div = document.createElement('div');
-      div.innerHTML = DOMPurify.sanitize(section.html);
-      div.style.marginBottom = '0.5rem';
-      content.appendChild(div);
-    });
+    fetch('help/quick-help.html')
+      .then(r => r.text())
+      .then(html => {
+        const temp = document.createElement('div');
+        temp.innerHTML = DOMPurify.sanitize(html, { ADD_TAGS: ['style'] });
+        Array.from(temp.children).forEach(child => content.appendChild(child));
+        // execute scripts from fetched HTML
+        content.querySelectorAll('script').forEach(oldScript => {
+          const s = document.createElement('script');
+          Array.from(oldScript.attributes).forEach(a => s.setAttribute(a.name, a.value));
+          s.textContent = oldScript.textContent;
+          oldScript.replaceWith(s);
+        });
+      })
+      .catch(() => {
+        content.textContent = 'Unable to load help content.';
+      });
 
     function applyTheme(theme){
       const colors = theme.colors || {};


### PR DESCRIPTION
## Summary
- add new public/help/quick-help.html using CSS variables and search/tag filtering
- fetch and inject quick help HTML in modal, applying current theme colors

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68acb23e35448328922304c86c5c0eef