### PR TITLE
feat: expand help guide

### DIFF
--- a/public/help/quick-help.html
+++ b/public/help/quick-help.html
@@ -1,99 +1,361 @@
 <style>
-:root {
-  color-scheme: light dark;
-}
-body {
-  background: var(--bg);
-  color: var(--text);
-  margin: 0;
-  font-family: sans-serif;
-}
-#help-container {
-  background: var(--panel);
-  padding: 1rem;
-  border-radius: 8px;
-  border: 1px solid var(--border);
-}
-#help-search {
-  width: 100%;
-  padding: 0.5rem;
-  margin-bottom: 1rem;
-  background: var(--panel2);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-}
-#help-tags { margin-bottom: 0.5rem; }
-.tag {
-  display: inline-block;
-  margin: 0 0.25rem 0.25rem 0;
-  padding: 0.1rem 0.5rem;
-  border-radius: 4px;
-  cursor: pointer;
-  background: var(--panel2);
-  color: var(--text);
-  border: 1px solid var(--border);
-  font-size: 0.8rem;
-}
-.tag.active {
-  background: var(--accent);
-  color: var(--text);
-}
-section { margin-bottom: 1rem; }
-section h2 {
-  margin: 0 0 0.5rem 0;
-  color: var(--accent);
-}
+  :root{
+    --bg:#0f0f14; --panel:#15151c; --panel2:#1c1c26; --text:#e8e8f0; --muted:#b8b8c2; --accent:#7c4dff; --accent-2:#9b6bff; --border:#262637; --ok:#2ecc71; --warn:#f39c12; --err:#e74c3c;
+    --radius:14px;
+  }
+  *{box-sizing:border-box}
+  html,body{height:100%}
+  body{margin:0;font:16px/1.55 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji","Segoe UI Emoji"; background:var(--bg); color:var(--text)}
+  .wrap{max-width:1100px;margin:0 auto;padding:32px 20px}
+  header{display:flex;flex-wrap:wrap;gap:16px;align-items:center;justify-content:space-between;margin-bottom:20px}
+  h1{font-size:28px;margin:0;letter-spacing:0.3px}
+  .search{display:flex;gap:10px;align-items:center;width:100%;max-width:600px;background:var(--panel);padding:10px 14px;border-radius:var(--radius);border:1px solid var(--border)}
+  .search input{flex:1; background:transparent;border:0;outline:none;color:var(--text);font-size:15px}
+  .tagbar{display:flex;flex-wrap:wrap;gap:8px;margin:10px 0 24px}
+  .chip{padding:6px 10px;border:1px solid var(--border);border-radius:999px;background:var(--panel);color:var(--muted);cursor:pointer;font-size:12px}
+  .chip.active{background:linear-gradient(135deg,var(--accent),var(--accent-2));color:white;border-color:transparent}
+
+  details.card{background:var(--panel);border:1px solid var(--border);border-radius:var(--radius);overflow:hidden;margin:12px 0}
+  details.card[open]{background:var(--panel2);border-color:#343451}
+  summary{cursor:pointer;list-style:none;padding:16px 18px;display:flex;gap:12px;align-items:center}
+  summary::-webkit-details-marker{display:none}
+  .bullet{width:10px;height:10px;border-radius:3px;background:var(--accent)}
+  .title{font-weight:600}
+  .subtitle{color:var(--muted);font-size:13px}
+  .section{padding:0 20px 18px}
+  .grid{display:grid;gap:10px}
+  .grid.two{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .box{background:rgba(255,255,255,0.03);border:1px solid var(--border);border-radius:12px;padding:12px}
+  h3{margin:16px 0 8px;font-size:16px}
+  h4{margin:14px 0 8px;font-size:14px;color:var(--muted);text-transform:uppercase;letter-spacing:0.08em}
+  ul{margin:8px 0 0 18px}
+  code{background:#101018;border:1px solid var(--border);padding:2px 6px;border-radius:6px}
+  .pill{display:inline-block;padding:2px 8px;border-radius:999px;font-size:12px;border:1px solid var(--border);color:var(--muted)}
+  .bad{color:var(--err)} .good{color:var(--ok)} .tip{color:var(--warn)}
+  footer{opacity:.65;margin-top:26px;font-size:13px}
+  a{color:#c9b6ff}
 </style>
-<div id="help-container">
-  <input id="help-search" type="search" placeholder="Search help..." />
-  <div id="help-tags"></div>
-  <div id="help-sections">
-    <section data-tags="getting started basics">
-      <h2>Getting Started</h2>
-      <p>Use the toolbar buttons to manipulate the diagram. Zoom with the ➕ and ➖ controls and use the tree view to navigate elements.</p>
-    </section>
-    <section data-tags="editing">
-      <h2>Editing</h2>
-      <p>Double‑click an element to edit its properties. Drag elements to reposition them. Use the palette to create new nodes.</p>
-    </section>
-    <section data-tags="simulation run">
-      <h2>Simulation</h2>
-      <p>Start the token simulation with the ▶ control. Pause with ⏸ or step through tokens using ⏭.</p>
-    </section>
-  </div>
+<div class="wrap">
+  <header>
+    <h1>🎯 BPMN Quick Help (for bpmn-js)</h1>
+    <div class="search" role="search">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path stroke="#8f8fb0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="m21 21-4.35-4.35M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z"/></svg>
+      <input id="q" placeholder="Search topics (try: start, gateway, boundary, lanes, message)…" />
+    </div>
+    <div class="tagbar" id="tags"></div>
+  </header>
+
+  <!-- Cards will be injected here -->
+  <div id="cards"></div>
+
+  <footer>
+    Optimized for dark-mode UIs. Drop this file into your app and mount within a modal or side panel. Content focuses on modeling with <code>bpmn-js</code> quick menu actions.
+  </footer>
 </div>
+
 <script>
-(function(){
-  const sections = Array.from(document.querySelectorAll('#help-sections section'));
-  const searchInput = document.getElementById('help-search');
-  const tagsContainer = document.getElementById('help-tags');
-  const tags = Array.from(new Set(sections.flatMap(s => (s.dataset.tags || '').split(/\s+/).filter(Boolean)))).sort();
-  let activeTag = '';
-  function filter(){
-    const q = searchInput.value.toLowerCase();
-    sections.forEach(s => {
-      const matchQuery = s.textContent.toLowerCase().includes(q);
-      const matchTag = !activeTag || (s.dataset.tags || '').split(/\s+/).includes(activeTag);
-      s.style.display = matchQuery && matchTag ? '' : 'none';
-    });
+// ---- Data Model ---------------------------------------------------------
+const HELP = [
+  {
+    id: 'start',
+    group: 'Events',
+    title: 'StartEvent — Entry point of the process',
+    subtitle: 'Creates the first token in a process or event sub-process.',
+    tags: ['events','start','trigger','message','timer','signal','conditional','multiple','event sub-process'],
+    blocks: [
+      { h3: 'What it is', items: [
+        'Marks where a process (or event sub-process) begins and creates the first token.'
+      ]},
+      { h3: 'Valid types', items: [
+        '<b>Top-level</b>: None, Message, Timer, Conditional, Signal, Multiple.',
+        '<b>Event Sub-Process</b>: Message, Timer, Conditional, Signal, <b>Error</b> (interrupting only), Escalation, Multiple, Parallel Multiple (interrupting / non-interrupting).'
+      ]},
+      { h3: 'Quick menu (bpmn-js)', items: [
+        'Replace → switch start type or toggle interrupting in event sub-process.',
+        'Append Task / Gateway / EndEvent.',
+        'Connect with Sequence Flow, add Text Annotation.'
+      ]},
+      { h3: 'Common mistakes', items: [
+        'End-only types (e.g., Terminate, Compensation) are <span class="bad">not</span> StartEvents.',
+        'Error/Escalation Start are only available in an <b>Event Sub-Process</b>.'
+      ]}
+    ]
+  },
+  {
+    id: 'task',
+    group: 'Activities',
+    title: 'Task — A unit of work',
+    subtitle: 'A single manual or automated step performed within the process.',
+    tags: ['task','user task','service task','manual task','script','send','receive','business rule','call activity'],
+    blocks: [
+      { h3: 'Task types', items: [
+        'None (generic), <b>User</b>, <b>Manual</b>, <b>Service</b>, <b>Script</b>, <b>Send</b>, <b>Receive</b>, <b>Business Rule</b>, and <b>Call Activity</b> (reusable).'
+      ]},
+      { h3: 'Quick menu', items: [
+        'Replace → change task subtype.',
+        'Append Task / Gateway / Intermediate / End.',
+        'Connect via Sequence Flow; add Annotation.'
+      ]},
+      { h3: 'When to use which', items: [
+        '<b>User</b>: human action via UI/form. <b>Service</b>: API/system call. <b>Script</b>: inline logic. <b>Manual</b>: offline work. <b>Send/Receive</b>: messaging. <b>Business Rule</b>: DMN. <b>Call Activity</b>: reuse.'
+      ]},
+      { h3: 'Common mistakes', items: [
+        'Using None Task for everything — be explicit later for clarity.',
+        'Confusing Script vs Service: Script runs inside the engine; Service calls out.'
+      ]}
+    ]
+  },
+  {
+    id: 'end',
+    group: 'Events',
+    title: 'EndEvent — Where the process finishes',
+    subtitle: 'Consumes the token; multiple ends represent different outcomes.',
+    tags: ['events','end','message','signal','error','escalation','terminate','cancel','compensation','multiple'],
+    blocks: [
+      { h3: 'End types', items: [
+        'None, <b>Message</b>, <b>Signal</b>, <b>Error</b>, <b>Escalation</b>, <b>Terminate</b>, <b>Cancel</b> (for Transactions), <b>Compensation</b>, <b>Multiple</b>.'
+      ]},
+      { h3: 'Quick menu', items: [
+        'Replace → swap end type.',
+        'Append/Connect upstream elements; add Annotation.'
+      ]},
+      { h3: 'When to use which', items: [
+        'Message/Signal: notify others; Error: throw problem; Escalation: raise without killing all; Terminate: hard stop; Cancel/Compensation: transaction/rollback.'
+      ]},
+      { h3: 'Common mistakes', items: [
+        'Using Terminate casually (kills all tokens).',
+        'Expecting None End to notify others — use Message/Signal.'
+      ]}
+    ]
+  },
+
+  // Gateways
+  {
+    id: 'gw-xor',
+    group: 'Gateways',
+    title: 'Exclusive Gateway (XOR) — One path only',
+    subtitle: 'Chooses exactly one outgoing path based on conditions; merges any one incoming token.',
+    tags: ['gateway','exclusive','xor','decision'],
+    blocks: [
+      { h3: 'Quick menu', items: ['Replace to another gateway; append elements; set conditions on outgoing flows.']},
+      { h3: 'Use for', items: ['Mutually exclusive outcomes (approve vs reject).']},
+      { h3: 'Common mistakes', items: ['Forgetting conditions → default path always taken.', 'Expecting multiple branches — use Inclusive or Parallel.']}
+    ]
+  },
+  {
+    id: 'gw-and',
+    group: 'Gateways',
+    title: 'Parallel Gateway (AND) — All paths at once',
+    subtitle: 'Splits into all outgoing paths; merge waits for tokens from all active incoming paths.',
+    tags: ['gateway','parallel','and','synchronization'],
+    blocks: [
+      { h3: 'Use for', items: ['Run tasks in parallel; synchronize later.']},
+      { h3: 'Common mistakes', items: ['Using instead of XOR (when only one branch is needed).','Deadlock by joining paths that may never all arrive.']}
+    ]
+  },
+  {
+    id: 'gw-or',
+    group: 'Gateways',
+    title: 'Inclusive Gateway (OR) — One or more paths',
+    subtitle: 'Splits into one or more branches; merge waits for all <i>active</i> incoming tokens.',
+    tags: ['gateway','inclusive','or'],
+    blocks: [
+      { h3: 'Use for', items: ['When multiple conditions can be true simultaneously.']},
+      { h3: 'Common mistakes', items: ['Using XOR when more than one branch may apply.', 'Forgetting merge waits only for active paths.']}
+    ]
+  },
+  {
+    id: 'gw-event',
+    group: 'Gateways',
+    title: 'Event-Based Gateway — Wait for first event',
+    subtitle: 'Routes based on whichever event occurs first; only events may follow directly.',
+    tags: ['gateway','event-based','race','timer','message'],
+    blocks: [
+      { h3: 'Use for', items: ['Races like “Message or Timeout, whichever happens first.”']},
+      { h3: 'Common mistakes', items: ['Placing tasks directly after it (must be catching events).','Expecting multiple paths — only one wins.']}
+    ]
+  },
+  {
+    id: 'gw-complex',
+    group: 'Gateways',
+    title: 'Complex Gateway — Advanced synchronization',
+    subtitle: 'Custom split/join rules (e.g., 3 of 5 tokens). Rare; engine support varies.',
+    tags: ['gateway','complex','advanced'],
+    blocks: [
+      { h3: 'Use for', items: ['When no other gateway can model the rule.']},
+      { h3: 'Caution', items: ['Harder to read/maintain; avoid unless necessary.']}
+    ]
+  },
+
+  // Intermediate Events
+  {
+    id: 'ie',
+    group: 'Events',
+    title: 'Intermediate Events — Something happens mid-process',
+    subtitle: 'Catching events wait; throwing events send. Inline or attached to activity boundaries.',
+    tags: ['events','intermediate','message','timer','conditional','signal','link','escalation','compensation','boundary','interrupting'],
+    blocks: [
+      { h3: 'Catching', items: ['Message, Timer, Conditional, Signal, Link, Multiple, Parallel Multiple.']},
+      { h3: 'Throwing', items: ['Message, Escalation, Compensation, Signal, Link.']},
+      { h3: 'Boundary events', items: ['Attach to Task/Sub-Process. <b>Solid</b> outline = interrupting, <b>dashed</b> = non-interrupting. Common: Timer, Error, Message, Escalation, Signal, Conditional, Compensation.']},
+      { h3: 'Common mistakes', items: ['Using Start/End icons by accident; throws do not wait; overusing Link events.']}
+    ]
+  },
+
+  // Sub-Processes
+  {
+    id: 'subproc',
+    group: 'Activities',
+    title: 'Sub-Processes — Encapsulated parts of the process',
+    subtitle: 'Containers with their own internal flow; can be embedded, reusable, transactional, or event-triggered.',
+    tags: ['activities','sub-process','call activity','transaction','event sub-process','collapse','expand'],
+    blocks: [
+      { h3: 'Types', items: [
+        '<b>Embedded</b> (plus marker): internal flow; not reusable.',
+        '<b>Call Activity</b> (thick border): references reusable process/global task.',
+        '<b>Transaction</b> (double border): all-or-nothing unit; supports Cancel/Compensation.',
+        '<b>Event Sub-Process</b> (dashed): triggered by event; interrupting or non-interrupting.'
+      ]},
+      { h3: 'Quick menu', items: ['Replace type; Expand/Collapse; Append; Attach boundary events; Connect flows; Add annotation.']},
+      { h3: 'Common mistakes', items: ['Overusing embedded sub-processes; forgetting Cancel/Compensation on transactions; assuming event sub-process starts via sequence flow (it does not).']}
+    ]
+  },
+
+  // Artifacts
+  {
+    id: 'artifacts',
+    group: 'Artifacts',
+    title: 'Artifacts — Information and context helpers',
+    subtitle: 'Do not move tokens; clarify data, groupings, and notes.',
+    tags: ['artifacts','data object','data store','group','annotation','association'],
+    blocks: [
+      { h3: 'Data Object', items: ['Represents info used/produced; mark as input/output; connect via <b>Data Association</b> (dotted).']},
+      { h3: 'Data Store', items: ['Persistent storage (DB, repo); connect via Data Association.']},
+      { h3: 'Group', items: ['Dashed container for visual grouping only (no execution semantics).']},
+      { h3: 'Text Annotation', items: ['Bracket note with dotted association; explain rules/comments.']},
+      { h3: 'Common mistakes', items: ['Using Sequence Flow instead of Data Association; assuming Group changes execution.']}
+    ]
+  },
+
+  // Swimlanes
+  {
+    id: 'swim',
+    group: 'Collaboration',
+    title: 'Swimlanes — Who does the work',
+    subtitle: 'Pools represent participants; Lanes divide responsibility within a pool.',
+    tags: ['pools','lanes','message flow','sequence flow','responsibility'],
+    blocks: [
+      { h3: 'Pool', items: ['Separate participant; tokens do <b>not</b> cross; communicate with <b>Message Flow</b> (dashed). Can be a black box.']},
+      { h3: 'Lane', items: ['Subdivision for roles/teams/components; tokens still move with Sequence Flow within the pool; lanes can nest.']},
+      { h3: 'Message vs Sequence Flow', items: ['Sequence (solid) stays in pool; Message (dashed open arrow) crosses pools and does not carry tokens.']},
+      { h3: 'Common mistakes', items: ['Connecting pools with Sequence Flow; too many lanes; over-modeling externals — use black-box pools.']}
+    ]
+  },
+
+  // Wrap-up
+  {
+    id: 'wrap',
+    group: 'Guides',
+    title: 'BPMN — Putting it all together',
+    subtitle: 'Practical tips for clear, valid diagrams in bpmn-js.',
+    tags: ['best practices','how to','guide'],
+    blocks: [
+      { h3: 'Core building blocks', items: [
+        'Events (Start/Intermediate/End), Activities (Tasks & Sub-Processes), Gateways, Artifacts, Swimlanes.',
+        'Flows: <b>Sequence</b> (solid, carries token), <b>Message</b> (dashed, across pools), <b>Data Association</b> (dotted).'
+      ]},
+      { h3: 'Quick menu tips', items: ['Replace type; Append next element; Connect flows; Add Annotations.']},
+      { h3: 'Best practices', items: [
+        'Model left→right; label everything; use lanes only when responsibility matters; collapse sub-processes for readability; handle exceptions with boundary events/event sub-processes; document with artifacts.'
+      ]},
+      { h3: 'Pitfalls', items: ['Mixing Message vs Sequence flows; wrong gateway choice; missing conditions on outgoing flows; treating BPMN as code instead of a communication tool.']}
+    ]
   }
-  tags.forEach(tag => {
-    const btn = document.createElement('button');
-    btn.textContent = tag;
-    btn.className = 'tag';
-    btn.addEventListener('click', () => {
-      activeTag = activeTag === tag ? '' : tag;
-      Array.from(tagsContainer.children).forEach(c => c.classList.toggle('active', c===btn && activeTag));
-      filter();
-    });
-    tagsContainer.appendChild(btn);
+];
+
+// ---- Rendering ----------------------------------------------------------
+const cardsEl = document.getElementById('cards');
+const tagsEl  = document.getElementById('tags');
+const qEl     = document.getElementById('q');
+
+const allTags = Array.from(new Set(HELP.flatMap(x=>x.tags))).sort((a,b)=>a.localeCompare(b));
+const active = new Set();
+
+function renderTags(){
+  tagsEl.innerHTML = '';
+  allTags.forEach(t=>{
+    const b = document.createElement('button');
+    b.className = 'chip'+(active.has(t)?' active':'');
+    b.textContent = t;
+    b.onclick = ()=>{ active.has(t) ? active.delete(t) : active.add(t); render(); };
+    tagsEl.appendChild(b);
   });
-  searchInput.addEventListener('input', filter);
-  if (location.hash){
-    const tag = location.hash.slice(1);
-    const btn = Array.from(tagsContainer.children).find(b => b.textContent === tag);
-    if (btn) btn.click();
+  if(active.size){
+    const clear = document.createElement('button');
+    clear.className = 'chip';
+    clear.textContent = 'clear filters';
+    clear.onclick = ()=>{ active.clear(); qEl.value=''; render(); };
+    tagsEl.appendChild(clear);
   }
-})();
+}
+
+function cardTemplate(item){
+  const det = document.createElement('details');
+  det.className = 'card';
+  det.id = item.id;
+  const sum = document.createElement('summary');
+  sum.innerHTML = `<span class="bullet"></span><div><div class="title">${item.title}</div><div class="subtitle">${item.subtitle}</div></div>`;
+  det.appendChild(sum);
+
+  const sec = document.createElement('div');
+  sec.className = 'section';
+
+  // group label
+  const lab = document.createElement('div');
+  lab.style.cssText='font-size:12px;color:var(--muted);text-transform:uppercase;letter-spacing:.12em;margin:0 0 6px 2px';
+  lab.textContent = item.group;
+  sec.appendChild(lab);
+
+  item.blocks.forEach(b=>{
+    const box = document.createElement('div');
+    box.className = 'box';
+    const h = document.createElement('h3');
+    h.innerHTML = b.h3; box.appendChild(h);
+    const ul = document.createElement('ul');
+    b.items.forEach(li=>{ const el = document.createElement('li'); el.innerHTML = li; ul.appendChild(el); });
+    box.appendChild(ul);
+    sec.appendChild(box);
+  });
+
+  // tag pills
+  const tagbox = document.createElement('div');
+  tagbox.style.marginTop = '10px';
+  item.tags.forEach(t=>{ const s = document.createElement('span'); s.className='pill'; s.textContent=t; s.style.marginRight='6px'; tagbox.appendChild(s);});
+  sec.appendChild(tagbox);
+
+  det.appendChild(sec);
+  return det;
+}
+
+function render(){
+  cardsEl.innerHTML='';
+  const q = qEl.value.trim().toLowerCase();
+
+  const filtered = HELP.filter(it=>{
+    const text = (it.title+' '+it.subtitle+' '+it.group+' '+it.tags.join(' ')+' '+it.blocks.flatMap(b=>b.items).join(' ')).toLowerCase();
+    const matchesQ = !q || text.includes(q);
+    const matchesTags = !active.size || it.tags.some(t=>active.has(t));
+    return matchesQ && matchesTags;
+  });
+
+  filtered.forEach(it=> cardsEl.appendChild(cardTemplate(it)));
+
+  // auto-open first match on typed search
+  if(q && filtered.length){ filtered[0].__openOnce || (document.getElementById(filtered[0].id).open = true, filtered[0].__openOnce=true); }
+}
+
+qEl.addEventListener('input', render);
+
+renderTags();
+render();
 </script>

--- a/public/js/components/helpGuide.js
+++ b/public/js/components/helpGuide.js
@@ -71,7 +71,13 @@
       .then(r => r.text())
       .then(html => {
         const temp = document.createElement('div');
-        temp.innerHTML = DOMPurify.sanitize(html, { ADD_TAGS: ['style'] });
+        temp.innerHTML = DOMPurify.sanitize(html, {
+          ADD_TAGS: ['style', 'svg', 'path'],
+          ADD_ATTR: [
+            'width', 'height', 'viewBox', 'fill', 'aria-hidden',
+            'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin', 'd'
+          ]
+        });
         Array.from(temp.children).forEach(child => content.appendChild(child));
         // execute scripts from fetched HTML
         content.querySelectorAll('script').forEach(oldScript => {


### PR DESCRIPTION
## Summary
- replace basic help popup content with comprehensive BPMN quick help guide
- allow DOMPurify to retain SVG icons and attributes when loading help

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68acb5c2fcac8328bc9d548184e1237c