### PR TITLE
Allow scripts in help guide HTML

### DIFF
--- a/public/js/components/helpGuide.js
+++ b/public/js/components/helpGuide.js
@@ -72,7 +72,7 @@
       .then(html => {
         const temp = document.createElement('div');
         temp.innerHTML = DOMPurify.sanitize(html, {
-          ADD_TAGS: ['style', 'svg', 'path'],
+          ADD_TAGS: ['style', 'svg', 'path', 'script'],
           ADD_ATTR: [
             'width', 'height', 'viewBox', 'fill', 'aria-hidden',
             'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin', 'd'


### PR DESCRIPTION
## Summary
- allow `script` tag through DOMPurify so help guide scripts execute

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install jsdom dompurify --no-save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68acbbaee2d8832895d86a7e88732da9