### PR TITLE
Parse and sanitize help guide HTML

### DIFF
--- a/public/js/components/helpGuide.js
+++ b/public/js/components/helpGuide.js
@@ -67,9 +67,10 @@
     const content = document.createElement('div');
     panel.appendChild(content);
 
-    const response = await fetch('bpmn_help_guide_embeddable_html.html');
+    const response = await fetch('/bpmn_help_guide_embeddable_html.html');
     const html = await response.text();
-    content.innerHTML = DOMPurify.sanitize(html);
+    const parsed = new DOMParser().parseFromString(html, 'text/html');
+    content.innerHTML = DOMPurify.sanitize(parsed.body.innerHTML);
 
     function applyTheme(theme){
       const colors = theme.colors || {};


### PR DESCRIPTION
## Summary
- Fetch help guide HTML from absolute root path to ensure correct retrieval
- Parse fetched HTML before sanitizing and injecting only body content

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adb21deb9883288b4b3c543fcaf8d7