### PR TITLE
Handle help guide fetch errors

### DIFF
--- a/public/js/components/helpGuide.js
+++ b/public/js/components/helpGuide.js
@@ -67,10 +67,18 @@
     const content = document.createElement('div');
     panel.appendChild(content);
 
-    const response = await fetch('/bpmn_help_guide_embeddable_html.html');
-    const html = await response.text();
-    const parsed = new DOMParser().parseFromString(html, 'text/html');
-    content.innerHTML = DOMPurify.sanitize(parsed.body.innerHTML);
+    try {
+      const response = await fetch('/bpmn_help_guide_embeddable_html.html');
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+      const html = await response.text();
+      const parsed = new DOMParser().parseFromString(html, 'text/html');
+      content.innerHTML = DOMPurify.sanitize(parsed.body.innerHTML);
+    } catch (err) {
+      console.error('Failed to load help guide:', err);
+      content.textContent = 'Error loading help guide.';
+    }
 
     function applyTheme(theme){
       const colors = theme.colors || {};


### PR DESCRIPTION
## Summary
- wrap help guide fetch logic with try/catch
- display a fallback error message in the modal and log failures

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adb2c7b5308328aebada2e5a9fd578