### PR TITLE
Fix help guide button by defining global opener

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -119,6 +119,10 @@ Object.assign(document.body.style, {
     if (e.target === helpGuideEl) helpGuideEl.hidden = true;
   });
 
+  window.openHelpGuideModal = () => {
+    helpGuideEl.hidden = false;
+  };
+
   // Touch interactions are handled via CSS (see `touch-action: none`).
   // Previously, we suppressed page scrolling by preventing the default
   // `touchmove` behavior on the canvas element which also blocked BPMN's
@@ -1068,9 +1072,7 @@ function rebuildMenu() {
   controls.push(
     reactiveButton(
       new Stream('❔'),
-      () => {
-        helpGuideEl.hidden = !helpGuideEl.hidden;
-      },
+      () => window.openHelpGuideModal(),
       { outline: true, title: 'Help guide' }
     )
   );


### PR DESCRIPTION
## Summary
- Define `openHelpGuideModal` on `window` to show the embedded help guide
- Update toolbar button to call the new opener

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adc67a2b24832884e8151a6d364e34