### PR TITLE
Handle missing help guide element

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -108,20 +108,24 @@ Object.assign(document.body.style, {
   const canvasEl = document.getElementById('canvas');
 
   const helpGuideEl = document.getElementById('help-guide');
-  const helpGuideCloseBtn = document.getElementById('help-guide-close');
-  if (helpGuideCloseBtn) {
-    helpGuideCloseBtn.addEventListener('click', () => {
-      helpGuideEl.hidden = true;
-    });
-  }
-
-  helpGuideEl.addEventListener('click', e => {
-    if (e.target === helpGuideEl) helpGuideEl.hidden = true;
-  });
 
   window.openHelpGuideModal = () => {
+    if (!helpGuideEl) return;
     helpGuideEl.hidden = false;
   };
+
+  if (helpGuideEl) {
+    const helpGuideCloseBtn = document.getElementById('help-guide-close');
+    if (helpGuideCloseBtn) {
+      helpGuideCloseBtn.addEventListener('click', () => {
+        helpGuideEl.hidden = true;
+      });
+    }
+
+    helpGuideEl.addEventListener('click', e => {
+      if (e.target === helpGuideEl) helpGuideEl.hidden = true;
+    });
+  }
 
   // Touch interactions are handled via CSS (see `touch-action: none`).
   // Previously, we suppressed page scrolling by preventing the default


### PR DESCRIPTION
## Summary
- safely register help guide event listeners only when element exists
- guard openHelpGuideModal to avoid runtime errors when help guide is absent

## Testing
- `npm test` (fails: Missing script "test")
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68adc92f3b74832885f288df05f2042d