### PR TITLE
Use hidden attribute to toggle help guide visibility

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -256,11 +256,18 @@
 #help-guide {
   position: fixed;
   inset: 0;
-  display: flex;
   align-items: center;
   justify-content: center;
   background: rgba(0, 0, 0, 0.6);
   z-index: 2000;
+}
+
+#help-guide[hidden] {
+  display: none;
+}
+
+#help-guide:not([hidden]) {
+  display: flex;
 }
 
 #help-guide iframe {


### PR DESCRIPTION
## Summary
- Hide help guide by default using the `hidden` attribute
- Display the guide when `hidden` is removed

## Testing
- `node - <<'NODE'
const helpGuideEl = { hidden: true };
function openHelpGuideModal(){ if (!helpGuideEl) return; helpGuideEl.hidden = false; }
function close(){ helpGuideEl.hidden = true; }
console.log('initial hidden:', helpGuideEl.hidden);
openHelpGuideModal();
console.log('after open hidden:', helpGuideEl.hidden);
close();
console.log('after close hidden:', helpGuideEl.hidden);
NODE`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adcd2e95b48328ae22436d99d42e8f