### PR TITLE
Expose theme variables to help guide

### DIFF
--- a/public/bpmn_help_guide_embeddable_html.html
+++ b/public/bpmn_help_guide_embeddable_html.html
@@ -6,10 +6,12 @@
   <title>BPMN Help Guide</title>
   <style>
     .help-guide-content{
-      --bg:#0f0f14; --panel:#15151c; --panel2:#1c1c26; --text:#e8e8f0; --muted:#b8b8c2; --accent:#7c4dff; --accent-2:#9b6bff; --border:#262637; --ok:#2ecc71; --warn:#f39c12; --err:#e74c3c;
       --radius:14px;
       height:100%;
-      margin:0;font:16px/1.55 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji","Segoe UI Emoji"; background:var(--bg); color:var(--text);
+      margin:0;
+      font:16px/1.55 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji","Segoe UI Emoji";
+      background:var(--bg);
+      color:var(--text);
     }
     .help-guide-content *{box-sizing:border-box}
     .wrap{max-width:1100px;margin:0 auto;padding:32px 20px}
@@ -19,10 +21,10 @@
     .search input{flex:1; background:transparent;border:0;outline:none;color:var(--text);font-size:15px}
     .tagbar{display:flex;flex-wrap:wrap;gap:8px;margin:10px 0 24px}
     .chip{padding:6px 10px;border:1px solid var(--border);border-radius:999px;background:var(--panel);color:var(--muted);cursor:pointer;font-size:12px}
-    .chip.active{background:linear-gradient(135deg,var(--accent),var(--accent-2));color:white;border-color:transparent}
+    .chip.active{background:linear-gradient(135deg,var(--accent),var(--accent-2));color:var(--text);border-color:transparent}
 
     details.card{background:var(--panel);border:1px solid var(--border);border-radius:var(--radius);overflow:hidden;margin:12px 0}
-    details.card[open]{background:var(--panel2);border-color:#343451}
+    details.card[open]{background:var(--panel2);border-color:var(--border)}
     summary{cursor:pointer;list-style:none;padding:16px 18px;display:flex;gap:12px;align-items:center}
     summary::-webkit-details-marker{display:none}
     .bullet{width:10px;height:10px;border-radius:3px;background:var(--accent)}
@@ -31,15 +33,15 @@
     .section{padding:0 20px 18px}
     .grid{display:grid;gap:10px}
     .grid.two{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
-    .box{background:rgba(255,255,255,0.03);border:1px solid var(--border);border-radius:12px;padding:12px}
+    .box{background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:12px}
     h3{margin:16px 0 8px;font-size:16px}
     h4{margin:14px 0 8px;font-size:14px;color:var(--muted);text-transform:uppercase;letter-spacing:0.08em}
     ul{margin:8px 0 0 18px}
-    code{background:#101018;border:1px solid var(--border);padding:2px 6px;border-radius:6px}
+    code{background:var(--panel2);border:1px solid var(--border);padding:2px 6px;border-radius:6px}
     .pill{display:inline-block;padding:2px 8px;border-radius:999px;font-size:12px;border:1px solid var(--border);color:var(--muted)}
     .bad{color:var(--err)} .good{color:var(--ok)} .tip{color:var(--warn)}
     footer{opacity:.65;margin-top:26px;font-size:13px}
-    a{color:#c9b6ff}
+    a{color:var(--accent-2)}
   </style>
 </head>
   <body>
@@ -48,7 +50,7 @@
     <header>
       <h1>🎯 BPMN Quick Help (for bpmn-js)</h1>
       <div class="search" role="search">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path stroke="#8f8fb0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="m21 21-4.35-4.35M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z"/></svg>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path stroke="var(--muted)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="m21 21-4.35-4.35M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z"/></svg>
         <input id="q" placeholder="Search topics (try: start, gateway, boundary, lanes, message)…" />
       </div>
       <div class="tagbar" id="tags"></div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -108,13 +108,22 @@ Object.assign(document.body.style, {
   const canvasEl = document.getElementById('canvas');
 
   const helpGuideEl = document.getElementById('help-guide');
-
   window.openHelpGuideModal = () => {
     if (!helpGuideEl) return;
     helpGuideEl.hidden = false;
   };
 
   if (helpGuideEl) {
+    const iframe = helpGuideEl.querySelector('iframe');
+    if (iframe) {
+      iframe.addEventListener('load', () => {
+        const body = iframe.contentDocument?.body;
+        if (!body) return;
+        applyThemeToPage(currentTheme.get(), body);
+        currentTheme.subscribe(theme => applyThemeToPage(theme, body));
+      });
+    }
+
     const helpGuideCloseBtn = document.getElementById('help-guide-close');
     if (helpGuideCloseBtn) {
       helpGuideCloseBtn.addEventListener('click', () => {

--- a/public/js/core/theme.js
+++ b/public/js/core/theme.js
@@ -346,6 +346,24 @@ function applyThemeToPage(theme, container = document.body) {
   container.style.fontFamily = fonts.base || 'sans-serif';
   container.style.transition = 'background-color 0.3s ease, color 0.3s ease';
 
+  const vars = {
+    '--bg': colors.bg || colors.background,
+    '--panel': colors.panel || colors.primary,
+    '--panel2': colors.panel2 || colors.surface,
+    '--text': colors.text || colors.foreground,
+    '--muted': colors.muted,
+    '--accent': colors.accent,
+    '--accent-2': colors['accent-2'] || colors.accent2 || colors.accent,
+    '--border': colors.border,
+    '--ok': colors.ok,
+    '--warn': colors.warn,
+    '--err': colors.err
+  };
+
+  Object.entries(vars).forEach(([key, value]) => {
+    if (value) container.style.setProperty(key, value);
+  });
+
   // Optional: smooth font weight rendering
   container.style.webkitFontSmoothing = 'antialiased';
   container.style.mozOsxFontSmoothing = 'grayscale';


### PR DESCRIPTION
## Summary
- propagate theme colors as CSS custom properties via `applyThemeToPage`
- initialize and reactively update help-guide iframe with current theme
- let help guide styles consume CSS variables instead of hard-coded colors

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68add0e53dd8832887010725c4c62bd8