### PR TITLE
Apply theme when help guide iframe already loaded

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -116,12 +116,18 @@ Object.assign(document.body.style, {
   if (helpGuideEl) {
     const iframe = helpGuideEl.querySelector('iframe');
     if (iframe) {
-      iframe.addEventListener('load', () => {
+      const applyIframeTheme = () => {
         const body = iframe.contentDocument?.body;
         if (!body) return;
         applyThemeToPage(currentTheme.get(), body);
         currentTheme.subscribe(theme => applyThemeToPage(theme, body));
-      });
+      };
+
+      if (iframe.contentDocument?.readyState === 'complete') {
+        applyIframeTheme();
+      }
+
+      iframe.addEventListener('load', applyIframeTheme);
     }
 
     const helpGuideCloseBtn = document.getElementById('help-guide-close');


### PR DESCRIPTION
## Summary
- Apply theme to help guide iframe immediately if already loaded
- Keep load handler for applying theme when iframe loads later

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68add817b11483288ebf94f39d169955