### PR TITLE
feat: support multi-flow selection

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -519,11 +519,17 @@ Object.assign(document.body.style, {
   // Prompt user to choose path at gateways
   simulation.pathsStream.subscribe(flows => {
     if (!flows || !flows.length) return;
+    const gatewayType = flows[0].source?.type;
+    const isInclusive = gatewayType === 'bpmn:InclusiveGateway';
     // Access modal helper via `window` to avoid ReferenceError when used
     // within modules or strict scopes
-    window.openFlowSelectionModal(flows, currentTheme).subscribe(chosen => {
-      if (chosen) {
-        simulation.step(chosen.id);
+    window.openFlowSelectionModal(flows, currentTheme, isInclusive).subscribe(chosen => {
+      if (chosen && chosen.length) {
+        if (isInclusive) {
+          simulation.step(chosen.map(f => f.id));
+        } else {
+          simulation.step(chosen[0].id);
+        }
       }
     });
   });

--- a/public/js/components/elements.js
+++ b/public/js/components/elements.js
@@ -433,7 +433,7 @@ function headerContainer(titleStream) {
 }
 
 
-function openFlowSelectionModal(flows, themeStream = currentTheme) {
+function openFlowSelectionModal(flows, themeStream = currentTheme, allowMultiple = false) {
   const pickStream = new Stream(null);
 
   // Overlay
@@ -476,21 +476,40 @@ function openFlowSelectionModal(flows, themeStream = currentTheme) {
   content.appendChild(list);
 
   flows.forEach(flow => {
-    const item = document.createElement('div');
-    item.textContent = flow.target?.businessObject?.name || flow.target?.id;
-    Object.assign(item.style, {
+    const label = document.createElement('label');
+    Object.assign(label.style, {
       padding: '0.5rem 1rem',
       borderRadius: '4px',
-      cursor: 'pointer'
+      cursor: 'pointer',
+      display: 'flex',
+      alignItems: 'center',
+      gap: '0.5rem'
     });
 
-    item.addEventListener('click', () => {
-      pickStream.set(flow);
-      modal.remove();
-    });
+    const input = document.createElement('input');
+    input.type = allowMultiple ? 'checkbox' : 'radio';
+    input.name = 'flowSelection';
 
-    list.appendChild(item);
+    const span = document.createElement('span');
+    span.textContent = flow.target?.businessObject?.name || flow.target?.id;
+
+    label.appendChild(input);
+    label.appendChild(span);
+    list.appendChild(label);
   });
+
+  const confirmBtn = document.createElement('button');
+  confirmBtn.textContent = 'Confirm';
+  confirmBtn.style.marginTop = '1rem';
+  confirmBtn.addEventListener('click', () => {
+    const selected = [];
+    list.querySelectorAll('input').forEach((input, idx) => {
+      if (input.checked) selected.push(flows[idx]);
+    });
+    pickStream.set(selected);
+    modal.remove();
+  });
+  content.appendChild(confirmBtn);
 
   modal.appendChild(content);
   document.body.appendChild(modal);
@@ -506,6 +525,10 @@ function openFlowSelectionModal(flows, themeStream = currentTheme) {
       child.onmouseover = () => child.style.backgroundColor = colors.accent + '55';
       child.onmouseout = () => child.style.backgroundColor = colors.primary || '#f9f9f9';
     });
+    confirmBtn.style.backgroundColor = colors.primary || '#f9f9f9';
+    confirmBtn.style.border = `1px solid ${colors.border || '#ccc'}`;
+    confirmBtn.onmouseover = () => confirmBtn.style.backgroundColor = colors.accent + '55';
+    confirmBtn.onmouseout = () => confirmBtn.style.backgroundColor = colors.primary || '#f9f9f9';
   };
 
   themeStream.subscribe(applyStyles);
@@ -513,7 +536,7 @@ function openFlowSelectionModal(flows, themeStream = currentTheme) {
 
   modal.addEventListener('click', e => {
     if (e.target === modal) {
-      pickStream.set(null);
+      pickStream.set([]);
       modal.remove();
     }
   });


### PR DESCRIPTION
## Summary
- allow multi-select in flow picker with confirm button
- detect inclusive gateways and pass selected path ids to simulation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check public/js/components/elements.js`
- `node --check public/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68adddb0e2348328842fecf00181394e