### PR TITLE
Include gateway type in path stream

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -517,10 +517,11 @@ Object.assign(document.body.style, {
   }
 
   // Prompt user to choose path at gateways
-  simulation.pathsStream.subscribe(flows => {
+  simulation.pathsStream.subscribe(data => {
+    if (!data) return;
+    const { flows, type } = data;
     if (!flows || !flows.length) return;
-    const gatewayType = flows[0].source?.type;
-    const isInclusive = gatewayType === 'bpmn:InclusiveGateway';
+    const isInclusive = type === 'bpmn:InclusiveGateway';
     // Access modal helper via `window` to avoid ReferenceError when used
     // within modules or strict scopes
     window.openFlowSelectionModal(flows, currentTheme, isInclusive).subscribe(chosen => {

--- a/public/js/core/simulation.js
+++ b/public/js/core/simulation.js
@@ -187,7 +187,7 @@ let nextTokenId = 1;
   function handleExclusiveGateway(token, outgoing, flowId) {
     if (!flowId) {
       console.log('Awaiting decision at gateway', token.element.id);
-      pathsStream.set(outgoing);
+      pathsStream.set({ flows: outgoing, type: token.element.type });
       awaitingToken = token;
       resumeAfterChoice = running;
       pause();
@@ -218,7 +218,7 @@ let nextTokenId = 1;
     const ids = Array.isArray(flowIds) ? flowIds : flowIds ? [flowIds] : null;
     if (!ids || ids.length === 0) {
       console.log('Awaiting inclusive decision at gateway', token.element.id);
-      pathsStream.set(outgoing);
+      pathsStream.set({ flows: outgoing, type: token.element.type });
       awaitingToken = token;
       resumeAfterChoice = running;
       pause();
@@ -242,7 +242,7 @@ let nextTokenId = 1;
   function handleEventBasedGateway(token, outgoing, flowId) {
     if (!flowId) {
       console.log('Awaiting event at gateway', token.element.id);
-      pathsStream.set(outgoing);
+      pathsStream.set({ flows: outgoing, type: token.element.type });
       awaitingToken = token;
       resumeAfterChoice = running;
       pause();


### PR DESCRIPTION
## Summary
- include element type when broadcasting gateway paths
- update path selection listener to handle new stream payload

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adde7dcdd883289922c6b79300e977