### PR TITLE
Add inclusive split/join simulation tests and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm install
+      - run: node --test

--- a/tests/simulation/inclusive-split-join.test.js
+++ b/tests/simulation/inclusive-split-join.test.js
@@ -1,0 +1,117 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadSimulation() {
+  const sandbox = {
+    console,
+    setTimeout,
+    clearTimeout,
+    localStorage: {
+      _data: {},
+      getItem(key) { return this._data[key] || null; },
+      setItem(key, val) { this._data[key] = String(val); },
+      removeItem(key) { delete this._data[key]; }
+    }
+  };
+  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
+  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
+  vm.runInNewContext(streamCode, sandbox);
+  vm.runInNewContext(simulationCode, sandbox);
+  return sandbox.createSimulation;
+}
+
+function createSimulationInstance(elements, opts = {}) {
+  const map = new Map(elements.map(e => [e.id, e]));
+  const elementRegistry = {
+    get(id) { return map.get(id); },
+    filter(fn) { return Array.from(map.values()).filter(fn); }
+  };
+  const canvas = { addMarker() {}, removeMarker() {} };
+  const createSimulation = loadSimulation();
+  return createSimulation({ elementRegistry, canvas }, opts);
+}
+
+function buildSplitJoinDiagram(extraTaskOnB = false) {
+  const start = { id: 'start', type: 'bpmn:StartEvent', outgoing: [], incoming: [], businessObject: { $type: 'bpmn:StartEvent' } };
+  const split = { id: 'split', type: 'bpmn:InclusiveGateway', businessObject: { gatewayDirection: 'Diverging' }, incoming: [], outgoing: [] };
+  const join = { id: 'join', type: 'bpmn:InclusiveGateway', businessObject: { gatewayDirection: 'Converging' }, incoming: [], outgoing: [] };
+  const end = { id: 'end', type: 'bpmn:Task', incoming: [], outgoing: [] };
+  const a = { id: 'a', type: 'bpmn:Task', incoming: [], outgoing: [] };
+  const b1 = { id: 'b1', type: 'bpmn:Task', incoming: [], outgoing: [] };
+
+  const f0 = { id: 'f0', source: start, target: split };
+  start.outgoing = [f0];
+  split.incoming = [f0];
+
+  const fa = { id: 'fa', source: split, target: a };
+  const fb = { id: 'fb', source: split, target: b1 };
+  split.outgoing = [fa, fb];
+  a.incoming = [fa];
+  b1.incoming = [fb];
+
+  const aj = { id: 'aj', source: a, target: join };
+  a.outgoing = [aj];
+  join.incoming = [aj];
+
+  const elements = [start, split, a, b1, join, end, f0, fa, fb, aj];
+
+  if (extraTaskOnB) {
+    const b2 = { id: 'b2', type: 'bpmn:Task', incoming: [], outgoing: [] };
+    const b1b2 = { id: 'b1b2', source: b1, target: b2 };
+    const b2j = { id: 'b2j', source: b2, target: join };
+    b1.outgoing = [b1b2];
+    b2.incoming = [b1b2];
+    b2.outgoing = [b2j];
+    join.incoming.push(b2j);
+    elements.push(b2, b1b2, b2j);
+  } else {
+    const b1j = { id: 'b1j', source: b1, target: join };
+    b1.outgoing = [b1j];
+    join.incoming.push(b1j);
+    elements.push(b1j);
+  }
+
+  const je = { id: 'je', source: join, target: end };
+  join.outgoing = [je];
+  end.incoming = [je];
+  elements.push(je);
+
+  return elements;
+}
+
+test('inclusive split/join with single selected path does not wait for others', () => {
+  const diagram = buildSplitJoinDiagram();
+  const sim = createSimulationInstance(diagram, { delay: 0 });
+  sim.reset();
+  sim.step(); // start -> split
+  sim.step(); // process gateway and wait for decision
+  sim.step(['fa']); // choose only path a
+  sim.step(); // a -> join
+  const afterA = Array.from(sim.tokenStream.get(), t => t.element.id);
+  assert.deepStrictEqual(afterA, ['join']);
+  sim.step(); // join -> end
+  const afterJoin = Array.from(sim.tokenStream.get(), t => t.element.id);
+  assert.deepStrictEqual(afterJoin, ['end']);
+});
+
+test('inclusive split/join waits for all selected branches', () => {
+  const diagram = buildSplitJoinDiagram(true);
+  const sim = createSimulationInstance(diagram, { delay: 0 });
+  sim.reset();
+  sim.step(); // start -> split
+  sim.step(); // process gateway and wait for decision
+  sim.step(['fa', 'fb']); // take both paths
+  sim.step(); // a -> join, b1 -> b2
+  const afterFirst = Array.from(sim.tokenStream.get(), t => t.element.id).sort();
+  assert.deepStrictEqual(afterFirst, ['b2', 'join']);
+  sim.step(); // join still waiting, b2 -> join
+  const afterSecond = Array.from(sim.tokenStream.get(), t => t.element.id).sort();
+  assert.deepStrictEqual(afterSecond, ['join', 'join']);
+  sim.step(); // join -> end
+  const afterMerge = Array.from(sim.tokenStream.get(), t => t.element.id);
+  assert.deepStrictEqual(afterMerge, ['end']);
+});
+


### PR DESCRIPTION
## Summary
- add simulation tests for inclusive split/join gateways
- cover single- and multi-branch scenarios
- run node --test in GitHub Actions

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68ae1c4b96a48328b1cc96facf501181