### PR TITLE
test: add exclusive gateway auto-selection cases

### DIFF
--- a/tests/simulation/exclusive-gateway.test.js
+++ b/tests/simulation/exclusive-gateway.test.js
@@ -1,0 +1,94 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadSimulation() {
+  const sandbox = {
+    console,
+    setTimeout,
+    clearTimeout,
+    localStorage: {
+      _data: {},
+      getItem(key) { return this._data[key] || null; },
+      setItem(key, val) { this._data[key] = String(val); },
+      removeItem(key) { delete this._data[key]; }
+    }
+  };
+  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
+  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
+  vm.runInNewContext(streamCode, sandbox);
+  vm.runInNewContext(simulationCode, sandbox);
+  return sandbox.createSimulation;
+}
+
+function createSimulationInstance(elements, opts = {}) {
+  const map = new Map(elements.map(e => [e.id, e]));
+  const elementRegistry = {
+    get(id) { return map.get(id); },
+    filter(fn) { return Array.from(map.values()).filter(fn); }
+  };
+  const canvas = { addMarker() {}, removeMarker() {} };
+  const createSimulation = loadSimulation();
+  return createSimulation({ elementRegistry, canvas }, opts);
+}
+
+function buildSingleConditionalDiagram() {
+  const start = { id: 'start', type: 'bpmn:StartEvent', outgoing: [], incoming: [], businessObject: { $type: 'bpmn:StartEvent' } };
+  const gw = { id: 'gw', type: 'bpmn:ExclusiveGateway', businessObject: { gatewayDirection: 'Diverging' }, incoming: [], outgoing: [] };
+  const a = { id: 'a', type: 'bpmn:Task', incoming: [], outgoing: [] };
+
+  const f0 = { id: 'f0', source: start, target: gw };
+  start.outgoing = [f0];
+  gw.incoming = [f0];
+
+  const f1 = { id: 'f1', source: gw, target: a, businessObject: { conditionExpression: { body: '${true}' } } };
+  gw.outgoing = [f1];
+  a.incoming = [f1];
+
+  return [start, gw, a, f0, f1];
+}
+
+function buildDefaultFlowDiagram() {
+  const start = { id: 'start', type: 'bpmn:StartEvent', outgoing: [], incoming: [], businessObject: { $type: 'bpmn:StartEvent' } };
+  const gw = { id: 'gw', type: 'bpmn:ExclusiveGateway', businessObject: { gatewayDirection: 'Diverging' }, incoming: [], outgoing: [] };
+  const a = { id: 'a', type: 'bpmn:Task', incoming: [], outgoing: [] };
+  const b = { id: 'b', type: 'bpmn:Task', incoming: [], outgoing: [] };
+
+  const f0 = { id: 'f0', source: start, target: gw };
+  start.outgoing = [f0];
+  gw.incoming = [f0];
+
+  const f1 = { id: 'f1', source: gw, target: a, businessObject: { conditionExpression: { body: '${false}' } } };
+  const f2 = { id: 'f2', source: gw, target: b };
+  gw.outgoing = [f1, f2];
+  gw.businessObject.default = f2;
+  a.incoming = [f1];
+  b.incoming = [f2];
+
+  return [start, gw, a, b, f0, f1, f2];
+}
+
+test('exclusive gateway with single conditional flow is taken automatically', () => {
+  const diagram = buildSingleConditionalDiagram();
+  const sim = createSimulationInstance(diagram, { delay: 0 });
+  sim.reset();
+  sim.step(); // start -> gateway
+  sim.step(); // gateway evaluates and takes conditional flow
+  const after = Array.from(sim.tokenStream.get(), t => t.element.id);
+  assert.deepStrictEqual(after, ['a']);
+  assert.strictEqual(sim.pathsStream.get(), null);
+});
+
+test('exclusive gateway chooses default flow when conditions not met', () => {
+  const diagram = buildDefaultFlowDiagram();
+  const sim = createSimulationInstance(diagram, { delay: 0 });
+  sim.reset();
+  sim.step(); // start -> gateway
+  sim.step(); // gateway evaluates and takes default flow
+  const after = Array.from(sim.tokenStream.get(), t => t.element.id);
+  assert.deepStrictEqual(after, ['b']);
+  assert.strictEqual(sim.pathsStream.get(), null);
+});
+


### PR DESCRIPTION
## Summary
- add simulation tests for exclusive gateways with single conditional flow and default flow

## Testing
- `node --test tests/simulation`


------
https://chatgpt.com/codex/tasks/task_e_68ae220199c883288594029224268326