### PR TITLE
Automatically choose first viable flow in exclusive gateway simulation

### DIFF
--- a/public/js/core/simulation.js
+++ b/public/js/core/simulation.js
@@ -210,20 +210,11 @@ let nextTokenId = 1;
         }
       }
 
-      if (viable.length === 1) {
-        const flow = viable[0];
+      const flow = viable[0];
+      if (flow) {
         const next = { id: token.id, element: flow.target, pendingJoins: token.pendingJoins };
         logToken(next);
         return [next];
-      }
-
-      if (viable.length > 1) {
-        console.log('Awaiting decision at gateway', token.element.id);
-        pathsStream.set({ flows: viable, type: token.element.type });
-        awaitingToken = token;
-        resumeAfterChoice = running;
-        pause();
-        return null;
       }
 
       return [];

--- a/tests/simulation/exclusive-gateway.multiple.test.js
+++ b/tests/simulation/exclusive-gateway.multiple.test.js
@@ -1,0 +1,66 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadSimulation() {
+  const sandbox = {
+    console,
+    setTimeout,
+    clearTimeout,
+    localStorage: {
+      _data: {},
+      getItem(key) { return this._data[key] || null; },
+      setItem(key, val) { this._data[key] = String(val); },
+      removeItem(key) { delete this._data[key]; }
+    }
+  };
+  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
+  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
+  vm.runInNewContext(streamCode, sandbox);
+  vm.runInNewContext(simulationCode, sandbox);
+  return sandbox.createSimulation;
+}
+
+function createSimulationInstance(elements, opts = {}) {
+  const map = new Map(elements.map(e => [e.id, e]));
+  const elementRegistry = {
+    get(id) { return map.get(id); },
+    filter(fn) { return Array.from(map.values()).filter(fn); }
+  };
+  const canvas = { addMarker() {}, removeMarker() {} };
+  const createSimulation = loadSimulation();
+  return createSimulation({ elementRegistry, canvas }, opts);
+}
+
+function buildMultipleConditionalDiagram() {
+  const start = { id: 'start', type: 'bpmn:StartEvent', outgoing: [], incoming: [], businessObject: { $type: 'bpmn:StartEvent' } };
+  const gw = { id: 'gw', type: 'bpmn:ExclusiveGateway', businessObject: { gatewayDirection: 'Diverging' }, incoming: [], outgoing: [] };
+  const a = { id: 'a', type: 'bpmn:Task', incoming: [], outgoing: [] };
+  const b = { id: 'b', type: 'bpmn:Task', incoming: [], outgoing: [] };
+
+  const f0 = { id: 'f0', source: start, target: gw };
+  start.outgoing = [f0];
+  gw.incoming = [f0];
+
+  const f1 = { id: 'f1', source: gw, target: a, businessObject: { conditionExpression: { body: '${true}' } } };
+  const f2 = { id: 'f2', source: gw, target: b, businessObject: { conditionExpression: { body: '${true}' } } };
+  gw.outgoing = [f1, f2];
+  a.incoming = [f1];
+  b.incoming = [f2];
+
+  return [start, gw, a, b, f0, f1, f2];
+}
+
+test('exclusive gateway chooses first of multiple viable flows automatically', () => {
+  const diagram = buildMultipleConditionalDiagram();
+  const sim = createSimulationInstance(diagram, { delay: 0 });
+  sim.reset();
+  sim.step(); // start -> gateway
+  sim.step(); // gateway evaluates and selects first flow
+  const after = Array.from(sim.tokenStream.get(), t => t.element.id);
+  assert.deepStrictEqual(after, ['a']);
+  assert.strictEqual(sim.pathsStream.get(), null);
+});
+


### PR DESCRIPTION
## Summary
- auto-select first viable flow for exclusive gateways to avoid manual intervention
- add regression test covering multiple viable flows

## Testing
- `node --test tests/simulation/*.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae241accf4832888438bc5f2f173ca