### PR TITLE
Handle implicit inclusive splits

### DIFF
--- a/public/js/core/simulation.js
+++ b/public/js/core/simulation.js
@@ -305,7 +305,11 @@ let nextTokenId = 1;
 
   function handleInclusiveGateway(token, outgoing, flowIds) {
     const direction = token.element.businessObject?.gatewayDirection;
-    if (direction !== 'Diverging' || outgoing.length <= 1) {
+    const incomingCount = (token.element.incoming || []).length;
+    const diverging =
+      outgoing.length > 1 &&
+      (direction === 'Diverging' || (!direction && incomingCount <= 1));
+    if (!diverging) {
       return handleDefault(token, outgoing);
     }
 


### PR DESCRIPTION
## Summary
- Treat inclusive gateways as diverging when gatewayDirection is missing but multiple outgoings exist
- Add test for inclusive split without gatewayDirection waiting for flow selection

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --test tests/simulation/*.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68ae2512607c8328995495e9eeecfbd0