### PR TITLE
test: add gateway behaviour tests

### DIFF
--- a/tests/simulation/exclusive-gateway-autoselect.test.js
+++ b/tests/simulation/exclusive-gateway-autoselect.test.js
@@ -1,0 +1,70 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadSimulation() {
+  const sandbox = {
+    console,
+    setTimeout,
+    clearTimeout,
+    localStorage: {
+      _data: {},
+      getItem(key) { return this._data[key] || null; },
+      setItem(key, val) { this._data[key] = String(val); },
+      removeItem(key) { delete this._data[key]; }
+    }
+  };
+  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
+  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
+  vm.runInNewContext(streamCode, sandbox);
+  vm.runInNewContext(simulationCode, sandbox);
+  return sandbox.createSimulation;
+}
+
+function createSimulationInstance(elements, opts = {}) {
+  const map = new Map(elements.map(e => [e.id, e]));
+  const elementRegistry = {
+    get(id) { return map.get(id); },
+    filter(fn) { return Array.from(map.values()).filter(fn); }
+  };
+  const canvas = { addMarker() {}, removeMarker() {} };
+  const createSimulation = loadSimulation();
+  return createSimulation({ elementRegistry, canvas }, opts);
+}
+
+function buildDiagram() {
+  const start = { id: 'start', type: 'bpmn:StartEvent', outgoing: [], incoming: [], businessObject: { $type: 'bpmn:StartEvent' } };
+  const gw = { id: 'gw', type: 'bpmn:ExclusiveGateway', businessObject: { gatewayDirection: 'Diverging' }, incoming: [], outgoing: [] };
+  const a = { id: 'a', type: 'bpmn:Task', incoming: [], outgoing: [] };
+  const b = { id: 'b', type: 'bpmn:Task', incoming: [], outgoing: [] };
+
+  const f0 = { id: 'f0', source: start, target: gw };
+  start.outgoing = [f0];
+  gw.incoming = [f0];
+
+  const fa = { id: 'fa', source: gw, target: a, businessObject: { conditionExpression: { body: '${true}' } } };
+  const fb = { id: 'fb', source: gw, target: b, businessObject: { conditionExpression: { body: '${true}' } } };
+  gw.outgoing = [fa, fb];
+  a.incoming = [fa];
+  b.incoming = [fb];
+
+  return [start, gw, a, b, f0, fa, fb];
+}
+
+test('exclusive gateway auto-selects one path when multiple conditions are true', () => {
+  // Exclusive gateways evaluate outgoing sequence flows in order and should
+  // automatically pick the first flow whose condition is true. Even if
+  // multiple conditions evaluate to true, only a single token continues and no
+  // user decision is requested.
+  const diagram = buildDiagram();
+  const sim = createSimulationInstance(diagram, { delay: 0 });
+  sim.reset();
+  sim.step(); // start -> gateway
+  sim.step(); // gateway auto-selects first matching flow
+  const tokens = Array.from(sim.tokenStream.get(), t => t.element.id);
+  assert.deepStrictEqual(tokens, ['a']);
+  assert.strictEqual(sim.pathsStream.get(), null);
+});
+

--- a/tests/simulation/inclusive-gateway-missing-direction.test.js
+++ b/tests/simulation/inclusive-gateway-missing-direction.test.js
@@ -1,0 +1,71 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadSimulation() {
+  const sandbox = {
+    console,
+    setTimeout,
+    clearTimeout,
+    localStorage: {
+      _data: {},
+      getItem(key) { return this._data[key] || null; },
+      setItem(key, val) { this._data[key] = String(val); },
+      removeItem(key) { delete this._data[key]; }
+    }
+  };
+  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
+  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
+  vm.runInNewContext(streamCode, sandbox);
+  vm.runInNewContext(simulationCode, sandbox);
+  return sandbox.createSimulation;
+}
+
+function createSimulationInstance(elements, opts = {}) {
+  const map = new Map(elements.map(e => [e.id, e]));
+  const elementRegistry = {
+    get(id) { return map.get(id); },
+    filter(fn) { return Array.from(map.values()).filter(fn); }
+  };
+  const canvas = { addMarker() {}, removeMarker() {} };
+  const createSimulation = loadSimulation();
+  return createSimulation({ elementRegistry, canvas }, opts);
+}
+
+function buildDiagram() {
+  const start = { id: 'start', type: 'bpmn:StartEvent', outgoing: [], incoming: [], businessObject: { $type: 'bpmn:StartEvent' } };
+  const gw = { id: 'gw', type: 'bpmn:InclusiveGateway', businessObject: {}, incoming: [], outgoing: [] };
+  const a = { id: 'a', type: 'bpmn:Task', incoming: [], outgoing: [] };
+  const b = { id: 'b', type: 'bpmn:Task', incoming: [], outgoing: [] };
+
+  const f0 = { id: 'f0', source: start, target: gw };
+  start.outgoing = [f0];
+  gw.incoming = [f0];
+
+  const fa = { id: 'fa', source: gw, target: a };
+  const fb = { id: 'fb', source: gw, target: b };
+  gw.outgoing = [fa, fb];
+  a.incoming = [fa];
+  b.incoming = [fb];
+
+  return [start, gw, a, b, f0, fa, fb];
+}
+
+test('inclusive gateway without gatewayDirection waits for explicit flow selection', () => {
+  // Inclusive gateways with multiple outgoing flows but no gatewayDirection are
+  // ambiguous. The simulator should pause at the gateway and expose the
+  // available flows for an explicit user decision instead of choosing
+  // automatically.
+  const diagram = buildDiagram();
+  const sim = createSimulationInstance(diagram, { delay: 0 });
+  sim.reset();
+  sim.step(); // start -> gateway
+  sim.step(); // process gateway, should wait for decision
+  const paths = sim.pathsStream.get();
+  assert.ok(paths && paths.flows.map(f => f.id).sort().join(',') === 'fa,fb');
+  const tokens = Array.from(sim.tokenStream.get(), t => t.element.id);
+  assert.deepStrictEqual(tokens, ['gw']);
+});
+


### PR DESCRIPTION
## Summary
- add exclusive gateway test to ensure only one path is chosen when multiple conditions are true
- add inclusive gateway test verifying pause when gatewayDirection is missing

## Testing
- `node --test tests/simulation`


------
https://chatgpt.com/codex/tasks/task_e_68ae2602dca08328b557cd38371f0187