### PR TITLE
feat: require explicit choice for exclusive gateway

### DIFF
--- a/public/js/core/simulation.js
+++ b/public/js/core/simulation.js
@@ -210,14 +210,18 @@ let nextTokenId = 1;
         }
       }
 
-      const flow = viable[0];
-      if (flow) {
+      if (viable.length === 1) {
+        const flow = viable[0];
         const next = { id: token.id, element: flow.target, pendingJoins: token.pendingJoins };
         logToken(next);
         return [next];
       }
 
-      return [];
+      pathsStream.set({ flows: viable, type: token.element.type });
+      awaitingToken = token;
+      resumeAfterChoice = running;
+      pause();
+      return null;
     }
 
     // Flow was chosen explicitly

--- a/tests/simulation/exclusive-gateway-autoselect.test.js
+++ b/tests/simulation/exclusive-gateway-autoselect.test.js
@@ -53,18 +53,18 @@ function buildDiagram() {
   return [start, gw, a, b, f0, fa, fb];
 }
 
-test('exclusive gateway auto-selects one path when multiple conditions are true', () => {
-  // Exclusive gateways evaluate outgoing sequence flows in order and should
-  // automatically pick the first flow whose condition is true. Even if
-  // multiple conditions evaluate to true, only a single token continues and no
-  // user decision is requested.
+test('exclusive gateway pauses for choice when multiple conditions are true', () => {
+  // Exclusive gateways should pause and expose all viable flows when more than
+  // one condition evaluates to true so that a caller can choose explicitly.
   const diagram = buildDiagram();
   const sim = createSimulationInstance(diagram, { delay: 0 });
   sim.reset();
   sim.step(); // start -> gateway
-  sim.step(); // gateway auto-selects first matching flow
+  sim.step(); // gateway evaluates and waits for a decision
   const tokens = Array.from(sim.tokenStream.get(), t => t.element.id);
-  assert.deepStrictEqual(tokens, ['a']);
-  assert.strictEqual(sim.pathsStream.get(), null);
+  assert.deepStrictEqual(tokens, ['gw']);
+  const paths = sim.pathsStream.get();
+  assert.ok(paths);
+  assert.deepStrictEqual(paths.flows.map(f => f.id), ['fa', 'fb']);
 });
 


### PR DESCRIPTION
## Summary
- require explicit user choice when exclusive gateways have multiple viable flows
- emit available flows through `pathsStream` and pause tokens until selection
- add tests covering explicit choice behavior

## Testing
- `node --test tests/simulation/*.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae280e94b48328a933d6c81d4d0a6e