### PR TITLE
Handle Unspecified inclusive gateway direction

### DIFF
--- a/public/js/core/simulation.js
+++ b/public/js/core/simulation.js
@@ -312,7 +312,8 @@ let nextTokenId = 1;
     const incomingCount = (token.element.incoming || []).length;
     const diverging =
       outgoing.length > 1 &&
-      (direction === 'Diverging' || (!direction && incomingCount <= 1));
+      (direction === 'Diverging' ||
+        ((!direction || direction === 'Unspecified') && incomingCount <= 1));
     if (!diverging) {
       return handleDefault(token, outgoing);
     }

--- a/tests/simulation/inclusive-gateway-missing-direction.test.js
+++ b/tests/simulation/inclusive-gateway-missing-direction.test.js
@@ -53,6 +53,25 @@ function buildDiagram() {
   return [start, gw, a, b, f0, fa, fb];
 }
 
+function buildUnspecifiedDiagram() {
+  const start = { id: 'start', type: 'bpmn:StartEvent', outgoing: [], incoming: [], businessObject: { $type: 'bpmn:StartEvent' } };
+  const gw = { id: 'gw', type: 'bpmn:InclusiveGateway', businessObject: { gatewayDirection: 'Unspecified' }, incoming: [], outgoing: [] };
+  const a = { id: 'a', type: 'bpmn:Task', incoming: [], outgoing: [] };
+  const b = { id: 'b', type: 'bpmn:Task', incoming: [], outgoing: [] };
+
+  const f0 = { id: 'f0', source: start, target: gw };
+  start.outgoing = [f0];
+  gw.incoming = [f0];
+
+  const fa = { id: 'fa', source: gw, target: a };
+  const fb = { id: 'fb', source: gw, target: b };
+  gw.outgoing = [fa, fb];
+  a.incoming = [fa];
+  b.incoming = [fb];
+
+  return [start, gw, a, b, f0, fa, fb];
+}
+
 test('inclusive gateway without gatewayDirection waits for explicit flow selection', () => {
   // Inclusive gateways with multiple outgoing flows but no gatewayDirection are
   // ambiguous. The simulator should pause at the gateway and expose the
@@ -68,4 +87,19 @@ test('inclusive gateway without gatewayDirection waits for explicit flow selecti
   const tokens = Array.from(sim.tokenStream.get(), t => t.element.id);
   assert.deepStrictEqual(tokens, ['gw']);
 });
+
+test('inclusive gateway with "Unspecified" direction waits for explicit flow selection', () => {
+  // Treating gatewayDirection="Unspecified" like no direction should pause at the gateway
+  // and expose available flows for selection.
+  const diagram = buildUnspecifiedDiagram();
+  const sim = createSimulationInstance(diagram, { delay: 0 });
+  sim.reset();
+  sim.step(); // start -> gateway
+  sim.step(); // process gateway, should wait for decision
+  const paths = sim.pathsStream.get();
+  assert.ok(paths && paths.flows.map(f => f.id).sort().join(',') === 'fa,fb');
+  const tokens = Array.from(sim.tokenStream.get(), t => t.element.id);
+  assert.deepStrictEqual(tokens, ['gw']);
+});
+
 


### PR DESCRIPTION
## Summary
- Treat inclusive gateways with `gatewayDirection: "Unspecified"` like no direction when computing divergence
- Add tests verifying inclusive gateways with unspecified direction wait for explicit flow selection

## Testing
- `node --test tests/simulation`


------
https://chatgpt.com/codex/tasks/task_e_68ae2a480d3c8328b7b3bbea7c84d2c4