### PR TITLE
Expose global notesStream for diagram selection

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -24,6 +24,7 @@ let currentUser = null;
 
 
 const notesStream = new Stream(null);
+window.notesStream = notesStream;
 const defaultXml = `<?xml version="1.0" encoding="UTF-8"?>
   <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
                     xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -276,7 +276,7 @@ function openDiagramPickerModal(currentUser, themeStream = currentTheme) {
             .doc(entry.id)
             .get();
 
-          notesStream.set(entry.notes);
+          window.notesStream.set(entry.notes);
 
           pickStream.set({ id: entry.id, data: doc.data() });
           modal.remove();


### PR DESCRIPTION
## Summary
- Expose `notesStream` on the `window` object so other scripts can access it.
- Use the global `notesStream` when selecting diagrams in `login.js` to avoid `ReferenceError`.

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68ae2d36c8788328bd98614d1d5a1c69