### PR TITLE
Use modeling service for add-on updates

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -497,11 +497,10 @@ Object.assign(document.body.style, {
   function applyAddOnsToElements(data) {
     Object.entries(data || {}).forEach(([id, addOns]) => {
       const el = elementRegistry.get(id);
-      if (el && el.businessObject) {
-        const bo = el.businessObject;
-        bo.$attrs = bo.$attrs || {};
-        bo.$attrs.addOns = JSON.stringify(addOns);
-        delete bo.addOns;
+      if (el) {
+        modeling.updateProperties(el, {
+          addOns: JSON.stringify(addOns)
+        });
       }
     });
   }


### PR DESCRIPTION
## Summary
- avoid direct $attrs mutations by updating add-ons through modeling service

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae2f61d6548328a936c2d3066ca25e