### PR TITLE
Load login after app and guard notes stream

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -184,7 +184,6 @@
   <script src="js/blockchain.js"></script>
   <!-- 6) Your application code -->
   <script src="js/firebase.js"></script>
-  <script src="js/login.js"></script>
   <script src="js/addOnStore.js"></script>
   <script type="importmap">
   {
@@ -211,6 +210,7 @@
   }
   </script>
   <script type="module" src="js/app.js"></script>
+  <script src="js/login.js"></script>
   <script src="js/h1-check.js"></script>
   <script src="js/palette-toggle.js"></script>
   <!-- 7) more to come -->

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -276,7 +276,7 @@ function openDiagramPickerModal(currentUser, themeStream = currentTheme) {
             .doc(entry.id)
             .get();
 
-          window.notesStream.set(entry.notes);
+          if (window.notesStream) window.notesStream.set(entry.notes);
 
           pickStream.set({ id: entry.id, data: doc.data() });
           modal.remove();


### PR DESCRIPTION
## Summary
- load login.js after app.js to ensure notesStream is defined
- guard notes stream assignment to avoid ReferenceError

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68af1bdd77808328acc9881690237330