### PR TITLE
chore: remove stray console logs

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -588,7 +588,6 @@ async function appendXml(xml) {
     // Example: Optionally adjust the position of the imported elements
     modeling.moveElements([/* elements to move */], { x: 100, y: 100 });
 
-    console.log('Successfully appended BPMN diagram!');
   } catch (err) {
     console.error("Error appending BPMN XML:", err);
   }
@@ -659,14 +658,12 @@ const saveBtn = reactiveButton(
     // Destructure metadata from currentDiagramData
     const { name: initialName, versions } = currentDiagramData;
     const initialNotes = currentNotes;
-    console.log("185", initialNotes); // Check the current diagram data in console
 
     // Prompt the user to edit metadata (if necessary)
     promptDiagramMetadata(initialName, initialNotes, currentTheme).subscribe(async metadata => {
       if (!metadata) return; // If metadata is null, exit
 
-      // Check and log the metadata received
-      console.log("Metadata received:", metadata);
+      // Metadata received
 
       const localTimestamp = Date.now();
 
@@ -797,9 +794,7 @@ function buildDropdownOptions() {
         onClick: () => {
           openDiagramPickerModal(currentUser).subscribe(result => {
             if (result === null) {
-              console.log("🚫 Cancelled");
             } else if (result.new) {
-              console.log("🆕 Start new diagram");
               currentDiagramId = null;
               diagramDataStream.set(null);
               diagramName = null;
@@ -959,7 +954,6 @@ function buildDropdownOptions() {
           openAddOnChooserModal(currentUser).subscribe(selectedAddOn => {
             if (selectedAddOn) {
               // Process the selected AddOn (either picked, newly added, or edited)
-              console.log('Selected or newly added AddOn:', selectedAddOn);
 
               // 👉 Here you can attach it to your diagram element, if needed.
               // e.g., handleAttachmentSelection(selectedAddOn.address, ...);
@@ -996,7 +990,6 @@ function buildDropdownOptions() {
       onClick: () => {
         if (currentUser) {
           firebase.auth().signOut().then(() => {
-            console.log("👋 Logged out");
             logUser.set('👤 Login');
             avatarStream.set('flow.png');
             showSaveButton.set(false);
@@ -1009,11 +1002,9 @@ function buildDropdownOptions() {
           const userStream = reactiveLoginModal(currentTheme);
           userStream.subscribe(result => {
             if (result instanceof Error) {
-              showToast("Error: + result.message", { type: 'error' });                          
+              showToast("Error: + result.message", { type: 'error' });
             } else if (result === null) {
-              console.log("🚫 User cancelled login");
             } else {
-              console.log("✅ Logged in as", result.email);
               currentUser = result;
               logUser.set('👤 Logout');
               avatarStream.set('flowLoggedIn.png');
@@ -1219,7 +1210,6 @@ function clearModeler() {
     canvas.zoom('fit-viewport');
     diagramXMLStream.set(defaultXml);
     isDirty.set(false);
-    console.log("🧼 Modeler cleared and reset.");
   }).catch(err => {
     console.error("Failed to clear modeler:", err);
   });

--- a/public/js/components/elements.js
+++ b/public/js/components/elements.js
@@ -334,14 +334,8 @@ function reactiveButton(labelStream, onClick, options = {}, themeStream = curren
   }
 
   button.addEventListener('click', () => {
-    console.log('Button clicked', {
-      text: button.textContent,
-      disabled: button.disabled
-    });
     if (!button.disabled) {
       onClick();
-    } else {
-      console.log('Click ignored: button disabled');
     }
   });
 

--- a/public/js/components/jazira.doc
+++ b/public/js/components/jazira.doc
@@ -576,7 +576,7 @@ const form = column([
   row([
     spacer(),
     reactiveButton(Stream('Save'), () => {
-      console.log('Name:', name.get(), 'Category:', category.get());
+      /* handle save action */
     })
   ])
 ], { gap: '1rem', padding: '1rem' });
@@ -591,8 +591,8 @@ const form = column([
 ```js
 const userAvatar = Stream('/images/user.png');
 const menuItems = [
-  { label: 'Profile', onClick: () => console.log('Profile') },
-  { label: 'Logout', onClick: () => console.log('Logout') },
+  { label: 'Profile', onClick: () => {/* profile */} },
+  { label: 'Logout', onClick: () => {/* logout */} },
 ];
 
 const header = row([
@@ -612,7 +612,7 @@ const header = row([
 const onDelete = async () => {
   const confirmed = await showConfirmationDialog('Are you sure you want to delete this?', currentTheme);
   if (confirmed) {
-    console.log('Deleted!');
+    /* deletion confirmed */
   }
 };
 

--- a/public/js/components/showProperties.js
+++ b/public/js/components/showProperties.js
@@ -324,8 +324,6 @@ function showProperties(element, modeling, moddle, currentUser) {
       openAddOnChooserModal(currentUser, currentTheme).subscribe(selectedAddOn => {
         if (!selectedAddOn) return;
 
-        console.log("Selected AddOn:", selectedAddOn);
-
         const newEntry = {
           id: selectedAddOn.address,
           ...selectedAddOn
@@ -346,7 +344,6 @@ function showProperties(element, modeling, moddle, currentUser) {
           addOnStore.setAddOns(bo.id, currentAddOns);
         }
 
-        console.log("Updated AddOns array:", currentAddOns);
       });
     },
     { accent: true },

--- a/public/js/core/README.md
+++ b/public/js/core/README.md
@@ -19,7 +19,7 @@ const sim = createSimulation({ elementRegistry, canvas });
 sim.elementHandlers.set('bpmn:UserTask', (token, api) => {
   api.pause();
   // perform asynchronous work or wait for user input
-  api.addCleanup(() => console.log('cleanup')); // optional
+  api.addCleanup(() => {/* cleanup */}); // optional
   api.resume();
   return [token]; // keep or modify tokens
 });

--- a/public/js/core/simulation.js
+++ b/public/js/core/simulation.js
@@ -146,7 +146,6 @@ let nextTokenId = 1;
 
   // --- Default element handlers ---
   elementHandlers.set('bpmn:UserTask', (token, api) => {
-    console.log('Waiting at user task', token.element.id);
     api.pause();
     const to = setTimeout(() => {
       skipHandlerFor.add(token.id);
@@ -157,7 +156,6 @@ let nextTokenId = 1;
   });
 
   elementHandlers.set('bpmn:TimerEvent', (token, api) => {
-    console.log('Timer event triggered', token.element.id);
     api.pause();
     const to = setTimeout(() => {
       skipHandlerFor.add(token.id);
@@ -344,7 +342,6 @@ let nextTokenId = 1;
 
     const ids = Array.isArray(flowIds) ? flowIds : flowIds ? [flowIds] : null;
     if (!ids || ids.length === 0) {
-      console.log('Awaiting inclusive decision at gateway', token.element.id);
       pathsStream.set({ flows: outgoing, type: token.element.type });
       awaitingToken = token;
       resumeAfterChoice = running;
@@ -375,7 +372,6 @@ let nextTokenId = 1;
 
   function handleEventBasedGateway(token, outgoing, flowId) {
     if (!flowId) {
-      console.log('Awaiting event at gateway', token.element.id);
       pathsStream.set({ flows: outgoing, type: token.element.type });
       awaitingToken = token;
       resumeAfterChoice = running;
@@ -434,7 +430,6 @@ let nextTokenId = 1;
       pathsStream.set(null);
       tokenStream.set(tokens);
       if (!tokens.length) {
-        console.log('No outgoing flow, simulation finished');
         pause();
         cleanup();
         return;
@@ -503,7 +498,6 @@ let nextTokenId = 1;
     pathsStream.set(null);
 
     if (!tokens.length) {
-      console.log('No outgoing flow, simulation finished');
       pause();
       cleanup();
       return;
@@ -531,7 +525,6 @@ let nextTokenId = 1;
     tokens = [t];
     tokenStream.set(tokens);
     logToken(t);
-    console.log('Simulation started');
     running = true;
     schedule();
   }
@@ -539,7 +532,6 @@ let nextTokenId = 1;
   function resume() {
     if (running) return;
     clearHandlerState();
-    console.log('Simulation resumed');
     running = true;
     schedule();
   }
@@ -547,7 +539,6 @@ let nextTokenId = 1;
   function pause() {
     running = false;
     clearTimeout(timer);
-    console.log('Simulation paused');
     if (!tokens.length) {
       cleanup();
     }
@@ -568,7 +559,6 @@ let nextTokenId = 1;
     tokenStream.set(tokens);
     logToken(t);
     pathsStream.set(null);
-    console.log('Simulation reset to start element', startEl && startEl.id);
   }
 
   return {

--- a/public/js/core/stream.js
+++ b/public/js/core/stream.js
@@ -98,7 +98,7 @@ function fieldStream(sourceStream, fieldName) {
  *
  * Usage:
  * const [tickStream, stop] = intervalStream(1000, () => Date.now());
- * const unsub = tickStream.subscribe(console.log);
+ * const unsub = tickStream.subscribe(value => {/* handle value */});
  * // later: stop(); unsub();
  */
 function intervalStream(ms, fn) {
@@ -114,7 +114,7 @@ function intervalStream(ms, fn) {
  *
  * Usage:
  * const [doneStream, cancel] = timeoutStream(5000, 'done');
- * doneStream.subscribe(console.log);
+ * doneStream.subscribe(value => {/* handle completion */});
  * // later: cancel();
  */
 function timeoutStream(ms, value) {

--- a/public/js/h1-check.js
+++ b/public/js/h1-check.js
@@ -10,7 +10,7 @@
     }
 
     Object.keys(obj).forEach(function (key) {
-      console.log(key, obj[key]);
+      // noop: removed console output
     });
   }
 

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -215,7 +215,6 @@ function openDiagramPickerModal(currentUser, themeStream = currentTheme) {
 
         const name = entry.name || `Untitled (${entry.id})`;
         const notes = entry.notes || '';
-        console.log("194", notes);
 
         // Text container (left side)
         const textContainer = document.createElement('div');
@@ -944,10 +943,8 @@ function openAddOnModal(currentUser, mode = 'add', addOnData = null, themeStream
 
 async function refreshAddOns() {
   try {
-    console.log("Fetching AddOns...");
     const snap = await db.collection('users').doc(currentUser.uid).get();
     const list = (snap.data()?.addOns) || [];
-    console.log("Fetched AddOns: ", list);
     addOnsStream.set(list);
   } catch (err) {
     console.error("Failed to fetch AddOns: ", err);


### PR DESCRIPTION
## Summary
- clean up stray `console.log` statements in login, app flow, UI components, and simulation core
- strip debug logging from documentation examples

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af1c8897108328ac11958fd57b10d9