### PR TITLE
Reset processed token count on simulation reset

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -260,6 +260,7 @@ Object.assign(document.body.style, {
   const origReset = simulation.reset;
   simulation.reset = (...args) => {
     tokenPanel.hide();
+    processedTokens = 0;
     const res = origReset.apply(simulation, args);
     return res;
   };


### PR DESCRIPTION
## Summary
- Reset processedTokens to zero when simulation resets to ensure token log starts fresh

## Testing
- `node --test` *(fails: SyntaxError: Unexpected token '}')*

------
https://chatgpt.com/codex/tasks/task_e_68af20b3a3548328bd37dd5921536ba9