### PR TITLE
Reset blockchain when clearing token log

### DIFF
--- a/public/js/blockchain.js
+++ b/public/js/blockchain.js
@@ -94,6 +94,11 @@ class Blockchain {
     this.persist();
   }
 
+  reset() {
+    this.chain = [this.createGenesisBlock()];
+    this.persist();
+  }
+
   addPeer(url) {
     if (!this.peers.includes(url)) {
       this.peers.push(url);

--- a/public/js/components/tokenListPanel.js
+++ b/public/js/components/tokenListPanel.js
@@ -144,6 +144,9 @@
       if (global.simulation && typeof global.simulation.clearTokenLog === 'function') {
         global.simulation.clearTokenLog();
       }
+      if (global.blockchain && typeof global.blockchain.reset === 'function') {
+        global.blockchain.reset();
+      }
     });
 
     closeBtn.addEventListener('click', hide);


### PR DESCRIPTION
## Summary
- add Blockchain.reset() to wipe chain and persist fresh genesis block
- clear token log now also resets blockchain via new reset method

## Testing
- `node --test` *(fails: SyntaxError: Unexpected token '}' in stream.js when running tests)*

------
https://chatgpt.com/codex/tasks/task_e_68af22a0ac148328a2ac096a110aa46a