### PR TITLE
Handle undefined delivery status in Gateway_DeliveryCheck

### DIFF
--- a/sample-delivery.bpmn
+++ b/sample-delivery.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  id="Definitions_Delivery" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Delivery_Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Delivery"/>
+    <bpmn:exclusiveGateway id="Gateway_DeliveryCheck"/>
+    <bpmn:task id="Task_DeliverySuccess"/>
+    <bpmn:task id="Task_Dispute"/>
+    <bpmn:task id="Task_Investigate"/>
+    <bpmn:endEvent id="EndEvent"/>
+    <bpmn:sequenceFlow id="Flow_Start_Gateway" sourceRef="StartEvent_Delivery" targetRef="Gateway_DeliveryCheck"/>
+    <bpmn:sequenceFlow id="Flow_Success" sourceRef="Gateway_DeliveryCheck" targetRef="Task_DeliverySuccess">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${deliveryStatus === 'successful'}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Dispute" sourceRef="Gateway_DeliveryCheck" targetRef="Task_Dispute">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${deliveryStatus === 'disputed'}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Other" sourceRef="Gateway_DeliveryCheck" targetRef="Task_Investigate">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${deliveryStatus !== 'successful' &amp;&amp; deliveryStatus !== 'disputed'}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Success_End" sourceRef="Task_DeliverySuccess" targetRef="EndEvent"/>
+    <bpmn:sequenceFlow id="Flow_Dispute_End" sourceRef="Task_Dispute" targetRef="EndEvent"/>
+    <bpmn:sequenceFlow id="Flow_Other_End" sourceRef="Task_Investigate" targetRef="EndEvent"/>
+  </bpmn:process>
+</bpmn:definitions>

--- a/tests/simulation/delivery-gateway.test.js
+++ b/tests/simulation/delivery-gateway.test.js
@@ -1,0 +1,105 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadSimulation() {
+  const sandbox = {
+    console,
+    setTimeout,
+    clearTimeout,
+    localStorage: {
+      _data: {},
+      getItem(key) { return this._data[key] || null; },
+      setItem(key, val) { this._data[key] = String(val); },
+      removeItem(key) { delete this._data[key]; }
+    }
+  };
+  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
+  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
+  vm.runInNewContext(streamCode, sandbox);
+  vm.runInNewContext(simulationCode, sandbox);
+  return sandbox.createSimulation;
+}
+
+function createSimulationInstance(elements, opts = {}) {
+  const map = new Map(elements.map(e => [e.id, e]));
+  const elementRegistry = {
+    get(id) { return map.get(id); },
+    filter(fn) { return Array.from(map.values()).filter(fn); }
+  };
+  const canvas = { addMarker() {}, removeMarker() {} };
+  const createSimulation = loadSimulation();
+  return createSimulation({ elementRegistry, canvas }, opts);
+}
+
+function buildDeliveryCheckDiagram() {
+  const start = { id: 'start', type: 'bpmn:StartEvent', outgoing: [], incoming: [], businessObject: { $type: 'bpmn:StartEvent' } };
+  const gw = {
+    id: 'Gateway_DeliveryCheck',
+    type: 'bpmn:ExclusiveGateway',
+    businessObject: { gatewayDirection: 'Diverging' },
+    incoming: [],
+    outgoing: []
+  };
+  const success = { id: 'Task_DeliverySuccess', type: 'bpmn:Task', incoming: [], outgoing: [] };
+  const dispute = { id: 'Task_Dispute', type: 'bpmn:Task', incoming: [], outgoing: [] };
+  const other = { id: 'Task_Investigate', type: 'bpmn:Task', incoming: [], outgoing: [] };
+
+  const f0 = { id: 'f0', source: start, target: gw };
+  start.outgoing = [f0];
+  gw.incoming = [f0];
+
+  const fSuccess = {
+    id: 'fSuccess',
+    source: gw,
+    target: success,
+    businessObject: { conditionExpression: { body: "${deliveryStatus === 'successful'}" } }
+  };
+  const fDispute = {
+    id: 'fDispute',
+    source: gw,
+    target: dispute,
+    businessObject: { conditionExpression: { body: "${deliveryStatus === 'disputed'}" } }
+  };
+  const fOther = {
+    id: 'fOther',
+    source: gw,
+    target: other,
+    businessObject: {
+      conditionExpression: {
+        body: "${deliveryStatus !== 'successful' && deliveryStatus !== 'disputed'}"
+      }
+    }
+  };
+
+  gw.outgoing = [fSuccess, fDispute, fOther];
+  success.incoming = [fSuccess];
+  dispute.incoming = [fDispute];
+  other.incoming = [fOther];
+
+  return [start, gw, success, dispute, other, f0, fSuccess, fDispute, fOther];
+}
+
+test('token proceeds beyond Gateway_DeliveryCheck when deliveryStatus matches', () => {
+  const diagram = buildDeliveryCheckDiagram();
+  const sim = createSimulationInstance(diagram, { delay: 0 });
+  sim.reset();
+  sim.setContext({ deliveryStatus: 'successful' });
+  sim.step(); // start -> gateway
+  sim.step(); // gateway evaluates condition
+  const after = Array.from(sim.tokenStream.get(), t => t.element.id);
+  assert.deepStrictEqual(after, ['Task_DeliverySuccess']);
+});
+
+test('token takes fallback branch when deliveryStatus is unset', () => {
+  const diagram = buildDeliveryCheckDiagram();
+  const sim = createSimulationInstance(diagram, { delay: 0 });
+  sim.reset();
+  sim.step(); // start -> gateway
+  sim.step(); // gateway evaluates and takes default
+  const after = Array.from(sim.tokenStream.get(), t => t.element.id);
+  assert.deepStrictEqual(after, ['Task_Investigate']);
+});
+


### PR DESCRIPTION
## Summary
- model delivery workflow with explicit fallback branch for Gateway_DeliveryCheck
- ensure simulation context sets deliveryStatus before reaching gateway
- verify token flows through success and fallback paths

## Testing
- `node --test tests/simulation`


------
https://chatgpt.com/codex/tasks/task_e_68af27e90ce0832881027437f82ef482