### PR TITLE
Pass user to refresh AddOn query

### DIFF
--- a/public/js/login.js
+++ b/public/js/login.js
@@ -941,7 +941,7 @@ function openAddOnModal(currentUser, mode = 'add', addOnData = null, themeStream
   return modalStream;
 }
 
-async function refreshAddOns() {
+async function refreshAddOns(currentUser) {
   try {
     const snap = await db.collection('users').doc(currentUser.uid).get();
     const list = (snap.data()?.addOns) || [];
@@ -958,7 +958,7 @@ function truncate(str, length = 40) {
 
 function openAddOnChooserModal(currentUser, themeStream = currentTheme) {
 
-  refreshAddOns();
+  refreshAddOns(currentUser);
   const modalStream = new Stream(null);
 
   const modal = document.createElement('div');
@@ -1076,7 +1076,7 @@ function openAddOnChooserModal(currentUser, themeStream = currentTheme) {
           editStream.subscribe(updated => {
             if (updated) {
               showToast("AddOn updated!", { type: 'success' });
-              refreshAddOns();
+              refreshAddOns(currentUser);
             }
           });
         } catch (err) {
@@ -1114,7 +1114,7 @@ function openAddOnChooserModal(currentUser, themeStream = currentTheme) {
     addStream.subscribe(newAddOn => {
       if (newAddOn) {
         showToast("AddOn added!", { type: 'success' });
-        refreshAddOns();
+        refreshAddOns(currentUser);
       }
     });
   }, { accent: true }, themeStream);


### PR DESCRIPTION
## Summary
- Pass currentUser into `refreshAddOns` and use it for Firestore queries
- Forward `currentUser` to `refreshAddOns` in `openAddOnChooserModal` so AddOn list updates per user

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af2ab2b0348328b6b40a2485912b1c