### PR TITLE
Expose addOnsStream globally

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -17,6 +17,7 @@ import customReplaceModule from './modules/customReplaceMenuProvider.js';
   };
 // A reactive store of the current user’s addOns
 const addOnsStream = new Stream([]);
+window.addOnsStream = addOnsStream;
 // Example options for the avatar (styling options)
 const avatarOptions = { width: '60px', height: '60px', rounded: true };
 const logUser = new Stream('👤 Login');

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -945,7 +945,7 @@ async function refreshAddOns(currentUser) {
   try {
     const snap = await db.collection('users').doc(currentUser.uid).get();
     const list = (snap.data()?.addOns) || [];
-    addOnsStream.set(list);
+    window.addOnsStream.set(list);
   } catch (err) {
     console.error("Failed to fetch AddOns: ", err);
   }
@@ -1016,7 +1016,7 @@ function openAddOnChooserModal(currentUser, themeStream = currentTheme) {
     'Information': 'ℹ️'
   };
 
-  addOnsStream.subscribe(addOns => {
+  window.addOnsStream.subscribe(addOns => {
     listContainer.replaceChildren();
 
     if (!addOns.length) {
@@ -1088,7 +1088,7 @@ function openAddOnChooserModal(currentUser, themeStream = currentTheme) {
         const confirmed = await showConfirmationDialog("Are you sure you want to remove this AddOn from this list?", themeStream);
         if (confirmed) {
           addOns.splice(addOns.indexOf(addOn), 1);
-          addOnsStream.set([...addOns]);
+          window.addOnsStream.set([...addOns]);
         }
       }, {        
         padding: '0.25rem 0.75rem',


### PR DESCRIPTION
## Summary
- attach addOnsStream to window in app.js so it is globally available
- reference global window.addOnsStream in login.js when fetching, subscribing, and updating add-ons

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68af2b77830883288c2d956aa0601f00