### PR TITLE
Expose global currentUser and update references

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -22,6 +22,7 @@ window.addOnsStream = addOnsStream;
 const avatarOptions = { width: '60px', height: '60px', rounded: true };
 const logUser = new Stream('👤 Login');
 let currentUser = null;
+window.currentUser = currentUser;
 
 
 const notesStream = new Stream(null);
@@ -322,7 +323,7 @@ Object.assign(document.body.style, {
     const element = elementRegistry.get(id);
     if (element) {
       selectionService.select(element);
-      showProperties(element, modeling, moddle, currentUser);
+      showProperties(element, modeling, moddle);
     }
     window.diagramTree.setSelectedId(id);
   };
@@ -804,7 +805,7 @@ function buildDropdownOptions() {
         {
         label: "📋 Select or New Diagram",
         onClick: () => {
-          openDiagramPickerModal(currentUser).subscribe(result => {
+          openDiagramPickerModal().subscribe(result => {
             if (result === null) {
             } else if (result.new) {
               currentDiagramId = null;
@@ -962,8 +963,8 @@ function buildDropdownOptions() {
       },
       {
         label: "🧩 Add AddOns", 
-        onClick: () => {          
-          openAddOnChooserModal(currentUser).subscribe(selectedAddOn => {
+        onClick: () => {
+          openAddOnChooserModal().subscribe(selectedAddOn => {
             if (selectedAddOn) {
               // Process the selected AddOn (either picked, newly added, or edited)
 
@@ -1006,9 +1007,10 @@ function buildDropdownOptions() {
             avatarStream.set('flow.png');
             showSaveButton.set(false);
             currentUser = null;
+            window.currentUser = currentUser;
             rebuildMenu();
           }).catch(err => {
-            showToast("Logout failed: ", { type: 'error' });            
+            showToast("Logout failed: ", { type: 'error' });
           });
         } else {
           const userStream = reactiveLoginModal(currentTheme);
@@ -1018,6 +1020,7 @@ function buildDropdownOptions() {
             } else if (result === null) {
             } else {
               currentUser = result;
+              window.currentUser = currentUser;
               logUser.set('👤 Logout');
               avatarStream.set('flowLoggedIn.png');
               showSaveButton.set(true);
@@ -1132,7 +1135,7 @@ function rebuildMenu() {
   // 6) Wire up double-click on any BPMN element
   eventBus.on('element.dblclick', ({ element }) => {
     if (element.type && element.type.startsWith('bpmn:')) {
-      showProperties(element, modeling, moddle, currentUser);
+      showProperties(element, modeling, moddle);
     }
   });
 

--- a/public/js/components/showProperties.js
+++ b/public/js/components/showProperties.js
@@ -274,7 +274,7 @@ function openUrlModal(url) {
   document.body.appendChild(modal);
 }
 
-function showProperties(element, modeling, moddle, currentUser) {
+function showProperties(element, modeling, moddle) {
   const bo = element.businessObject;
   const type = element.businessObject.$type;
   const fieldKeys = BPMN_PROPERTY_MAP[type] || [];
@@ -321,7 +321,7 @@ function showProperties(element, modeling, moddle, currentUser) {
   const attachBtn = reactiveButton(
     new Stream("Attach AddOn"),
     () => {
-      openAddOnChooserModal(currentUser, currentTheme).subscribe(selectedAddOn => {
+      openAddOnChooserModal(currentTheme).subscribe(selectedAddOn => {
         if (!selectedAddOn) return;
 
         const newEntry = {

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -144,7 +144,7 @@ function reactiveLoginModal(themeStream = currentTheme) {
 
 
 
-function openDiagramPickerModal(currentUser, themeStream = currentTheme) {
+function openDiagramPickerModal(themeStream = currentTheme) {
   const pickStream = new Stream(null); // emits selected diagram or null
 
   // Modal base
@@ -188,7 +188,7 @@ function openDiagramPickerModal(currentUser, themeStream = currentTheme) {
   // Load diagrams from Firestore
   
   db.collection('users')
-  .doc(currentUser.uid)
+  .doc(window.currentUser.uid)
   .get()
   .then(doc => {
     const userData = doc.data();
@@ -250,7 +250,7 @@ function openDiagramPickerModal(currentUser, themeStream = currentTheme) {
             if (!confirmed) return;
 
             try {
-                const userRef = db.collection('users').doc(currentUser.uid);
+                const userRef = db.collection('users').doc(window.currentUser.uid);
                 const diagramRef = userRef.collection('diagrams').doc(entry.id);
 
                 await diagramRef.delete();
@@ -270,7 +270,7 @@ function openDiagramPickerModal(currentUser, themeStream = currentTheme) {
         // Click on main item to load
         item.addEventListener('click', async () => {
           const doc = await db.collection('users')
-            .doc(currentUser.uid)
+            .doc(window.currentUser.uid)
             .collection('diagrams')
             .doc(entry.id)
             .get();
@@ -534,7 +534,7 @@ function selectVersionModal(diagramName, versions, themeStream = currentTheme) {
 function handleAttachmentSelection(attachmentId, versionIndex) {
   // Fetch the attachment from Firestore
   db.collection('users')
-    .doc(currentUser.uid)
+    .doc(window.currentUser.uid)
     .collection('attachments')
     .doc(attachmentId)
     .get()
@@ -710,7 +710,7 @@ function typeChoices(type, ) {
 
 }
 
-function openAddOnModal(currentUser, mode = 'add', addOnData = null, themeStream = currentTheme) {
+function openAddOnModal(mode = 'add', addOnData = null, themeStream = currentTheme) {
   const modalStream = new Stream(null);  // Will emit the created or edited AddOn
   
   // ——— Backdrop ———
@@ -841,7 +841,7 @@ function openAddOnModal(currentUser, mode = 'add', addOnData = null, themeStream
       lastUpdated: firebase.firestore.FieldValue.serverTimestamp()
     };
 
-    const userRef = db.collection('users').doc(currentUser.uid);
+    const userRef = db.collection('users').doc(window.currentUser.uid);
     try {
       if (mode === 'add') {
         const version = {
@@ -941,9 +941,9 @@ function openAddOnModal(currentUser, mode = 'add', addOnData = null, themeStream
   return modalStream;
 }
 
-async function refreshAddOns(currentUser) {
+async function refreshAddOns() {
   try {
-    const snap = await db.collection('users').doc(currentUser.uid).get();
+    const snap = await db.collection('users').doc(window.currentUser.uid).get();
     const list = (snap.data()?.addOns) || [];
     window.addOnsStream.set(list);
   } catch (err) {
@@ -956,9 +956,9 @@ function truncate(str, length = 40) {
   return str.length > length ? str.slice(0, length) + '...' : str;
 }
 
-function openAddOnChooserModal(currentUser, themeStream = currentTheme) {
+function openAddOnChooserModal(themeStream = currentTheme) {
 
-  refreshAddOns(currentUser);
+  refreshAddOns();
   const modalStream = new Stream(null);
 
   const modal = document.createElement('div');
@@ -1071,12 +1071,12 @@ function openAddOnChooserModal(currentUser, themeStream = currentTheme) {
       editBtn.style.cursor = 'pointer';
       editBtn.onclick = async () => {
         try {
-          const fullData = await loadLatestAddOnVersion(currentUser, addOn.address);
-          const editStream = openAddOnModal(currentUser, 'edit', fullData, themeStream);
+          const fullData = await loadLatestAddOnVersion(addOn.address);
+          const editStream = openAddOnModal('edit', fullData, themeStream);
           editStream.subscribe(updated => {
             if (updated) {
               showToast("AddOn updated!", { type: 'success' });
-              refreshAddOns(currentUser);
+              refreshAddOns();
             }
           });
         } catch (err) {
@@ -1110,11 +1110,11 @@ function openAddOnChooserModal(currentUser, themeStream = currentTheme) {
   }, { outline: true }, themeStream);
 
   const newBtn = reactiveButton(new Stream("➕ New AddOn"), () => {
-    const addStream = openAddOnModal(currentUser, 'add', null, themeStream);
+    const addStream = openAddOnModal('add', null, themeStream);
     addStream.subscribe(newAddOn => {
       if (newAddOn) {
         showToast("AddOn added!", { type: 'success' });
-        refreshAddOns(currentUser);
+        refreshAddOns();
       }
     });
   }, { accent: true }, themeStream);
@@ -1137,9 +1137,9 @@ function openAddOnChooserModal(currentUser, themeStream = currentTheme) {
 
 
 
-async function loadLatestAddOnVersion(currentUser, addOnId) {
+async function loadLatestAddOnVersion(addOnId) {
   const doc = await db.collection('users')
-    .doc(currentUser.uid)
+    .doc(window.currentUser.uid)
     .collection('addOns')
     .doc(addOnId)
     .get();
@@ -1158,7 +1158,7 @@ async function loadLatestAddOnVersion(currentUser, addOnId) {
 }
 
 
-function openAddOnHistoryModal(currentUser, addOnId, themeStream = currentTheme) {
+function openAddOnHistoryModal(addOnId, themeStream = currentTheme) {
   const modal = document.createElement('div');
   Object.assign(modal.style, {
     position: 'fixed',
@@ -1205,7 +1205,7 @@ function openAddOnHistoryModal(currentUser, addOnId, themeStream = currentTheme)
   const loadHistory = async () => {
     try {
       const doc = await db.collection('users')
-        .doc(currentUser.uid)
+        .doc(window.currentUser.uid)
         .collection('addOns')
         .doc(addOnId)
         .get();


### PR DESCRIPTION
## Summary
- Expose the current user via `window.currentUser` after initialization and login/logout events
- Refactor login and add-on utilities to rely on `window.currentUser` instead of passing the user around
- Update property panel to use new add-on chooser API

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68af2c1603c48328ba022747e0fbb1d9