### PR TITLE
feat: share type icon map globally

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -15,6 +15,7 @@ import customReplaceModule from './modules/customReplaceMenuProvider.js';
     'Tool': '🧰',
     'Information': 'ℹ️'
   };
+  window.typeIcons = typeIcons;
 // A reactive store of the current user’s addOns
 const addOnsStream = new Stream([]);
 window.addOnsStream = addOnsStream;

--- a/public/js/components/showProperties.js
+++ b/public/js/components/showProperties.js
@@ -383,7 +383,7 @@ function showProperties(element, modeling, moddle) {
   row1.style.gap = '0.5rem';
 
   const icon = document.createElement('span');
-  icon.textContent = typeIcons[addOn.type] || '❓';
+  icon.textContent = (window.typeIcons || {})[addOn.type] || '❓';
   icon.style.fontSize = '1.5rem';
   row1.appendChild(icon);
 

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -1001,20 +1001,6 @@ function openAddOnChooserModal(themeStream = currentTheme) {
   });
   content.appendChild(listContainer);
 
-  const typeIcons = {
-    'Knowledge': '📚',
-    'Business': '💼',
-    'Requirement': '📝',
-    'Lifecycle': '🔄',
-    'Measurement': '📊',
-    'Condition': '⚖️',
-    'Material': '🧱',
-    'Role': '👤',
-    'Equipment': '🛠️',
-    'System': '⚙️',
-    'Tool': '🧰',
-    'Information': 'ℹ️'
-  };
 
   window.addOnsStream.subscribe(addOns => {
     listContainer.replaceChildren();
@@ -1048,7 +1034,7 @@ function openAddOnChooserModal(themeStream = currentTheme) {
       });
 
       const icon = document.createElement('span');
-      icon.textContent = typeIcons[addOn.type] || '❓';
+      icon.textContent = (window.typeIcons || {})[addOn.type] || '❓';
       icon.style.fontSize = '1.5rem';
       item.appendChild(icon);
 


### PR DESCRIPTION
## Summary
- expose `typeIcons` globally via `window.typeIcons`
- guard icon lookups against missing globals in properties and login views
- remove duplicate `typeIcons` definition so all scripts share one map

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68af3385e318832899ee96aa6fbc36cf