### PR TITLE
docs: add toolbar controls guide

### DIFF
--- a/public/bpmn_help_guide_embeddable_html.html
+++ b/public/bpmn_help_guide_embeddable_html.html
@@ -280,6 +280,29 @@
         ]},
         { h3: 'Pitfalls', items: ['Mixing Message vs Sequence flows; wrong gateway choice; missing conditions on outgoing flows; treating BPMN as code instead of a communication tool.']}
       ]
+    },
+
+    // Toolbar
+    {
+      id: 'toolbar',
+      group: 'Toolbar',
+      title: 'Toolbar Controls — Run and view options',
+      subtitle: 'Quick access to simulation and diagram tools.',
+      tags: ['toolbar','controls'],
+      blocks: [
+        { h3: 'Buttons', items: [
+          '▶️ Play — start simulation.',
+          '⏸️ Pause — halt execution.',
+          '⏭️ Step — advance token.',
+          '➕ Zoom In / ➖ Zoom Out — adjust view.',
+          '🔳 Fit — center diagram.',
+          '🖼️ PNG — export image.',
+          '💾 Save — download BPMN.',
+          '🌲 Tree — toggle element tree.',
+          '❓ Help — open this guide.',
+          '🌓 Theme — switch light/dark.'
+        ]}
+      ]
     }
   ];
 


### PR DESCRIPTION
## Summary
- document toolbar control icons and actions in embeddable help guide

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b084ca30e88328b70d86ea127f5960