### PR TITLE
Document simulation controls in help guide

### DIFF
--- a/public/bpmn_help_guide_embeddable_html.html
+++ b/public/bpmn_help_guide_embeddable_html.html
@@ -318,6 +318,27 @@
           '🌓 Theme — switch light/dark.'
         ]}
       ]
+    },
+
+    {
+      id: 'simulation',
+      group: 'Simulation',
+      title: 'Simulation — Playback and tokens',
+      subtitle: 'Control execution and inspect token state.',
+      tags: ['simulation','tokens','blockchain'],
+      blocks: [
+        { h3: 'Playback controls', items: [
+          '▶️ Play — begin or resume execution.',
+          '⏸️ Pause — suspend running tokens.',
+          '⏭️ Step — advance a single move.'
+        ]},
+        { h3: 'Token List', items: [
+          'Open the token list to see all active tokens during a run.'
+        ]},
+        { h3: 'Blockchain Log', items: [
+          'Download the blockchain log to review recorded events.'
+        ]}
+      ]
     }
   ];
 


### PR DESCRIPTION
## Summary
- add Simulation help entry detailing playback controls, token list, and blockchain log

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b08743d92c83288c039d1cce5ea551