### PR TITLE
docs: add help entry for add-on filters

### DIFF
--- a/public/bpmn_help_guide_embeddable_html.html
+++ b/public/bpmn_help_guide_embeddable_html.html
@@ -82,6 +82,18 @@
       ]
     },
     {
+      id: 'addons',
+      group: 'AddOns',
+      title: 'AddOns — Filter and manage extras',
+      subtitle: 'Toggle filters, refine types, and add features through the avatar menu.',
+      tags: ['addons','filters'],
+      blocks: [
+        { h3: 'Filter toggle', items: ['Show only elements with add-ons or reveal all items.']},
+        { h3: 'Select type / subtype', items: ['Pick an add-on type and optional subtype to narrow what is displayed.']},
+        { h3: 'Add AddOns (avatar menu)', items: ['Open the avatar menu → “Add AddOns” to attach tools and display the legend with counts if available.']}
+      ]
+    },
+    {
       id: 'start',
       group: 'Events',
       title: 'StartEvent — Entry point of the process',


### PR DESCRIPTION
## Summary
- document AddOns filter toggle, type selection, and avatar-menu usage in BPMN help guide

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b087def98c832889566cf6c8ff8b7e