### PR TITLE
Improve condition expression editing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -79,6 +79,11 @@
     right: 0;
   }
 
+  .props-sidebar textarea {
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
   @media (max-width: 1024px) {
     .props-sidebar {
       width: 80vw;

--- a/public/js/components/showProperties.js
+++ b/public/js/components/showProperties.js
@@ -722,7 +722,12 @@ function showProperties(element, modeling, moddle) {
     let input;
     if (type === 'textarea') {
       input = document.createElement('textarea');
-      input.rows = 3;
+      if (key === 'conditionExpression') {
+        input.rows = 4;
+        input.wrap = 'soft';
+      } else {
+        input.rows = 3;
+      }
     } else {
       input = document.createElement('input');
       input.type = type;


### PR DESCRIPTION
## Summary
- allow properties sidebar textareas to wrap and preserve whitespace
- expand conditionExpression editor for easier multi-line editing

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b47514c1488328a3b788e410c2c789