### PR TITLE
feat: add mapping fields to gateways

### DIFF
--- a/public/js/components/showProperties.js
+++ b/public/js/components/showProperties.js
@@ -98,7 +98,8 @@ const BPMN_PROPERTY_MAP = {
     'estimatedDuration', 'actualDuration',
   'costEstimate', 'ownerRole',
   'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime', 
+  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+  'variables', 'inputMappings', 'outputMappings',
   'kpiNotes'
   ],
   'bpmn:InclusiveGateway': [
@@ -106,7 +107,8 @@ const BPMN_PROPERTY_MAP = {
     'estimatedDuration', 'actualDuration',
   'costEstimate', 'ownerRole',
   'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime', 
+  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+  'variables', 'inputMappings', 'outputMappings',
   'kpiNotes'
   ],
   'bpmn:ParallelGateway': [
@@ -114,7 +116,8 @@ const BPMN_PROPERTY_MAP = {
     'estimatedDuration', 'actualDuration',
   'costEstimate', 'ownerRole',
   'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime', 
+  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+  'variables', 'inputMappings', 'outputMappings',
   'kpiNotes'
   ],
   'bpmn:ComplexGateway': [
@@ -122,7 +125,8 @@ const BPMN_PROPERTY_MAP = {
     'estimatedDuration', 'actualDuration',
   'costEstimate', 'ownerRole',
   'inputQuality', 'outputQuality',
-    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime', 
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+  'variables', 'inputMappings', 'outputMappings',
   'kpiNotes'
   ],
   'bpmn:EventBasedGateway': [
@@ -130,7 +134,8 @@ const BPMN_PROPERTY_MAP = {
     'estimatedDuration', 'actualDuration',
   'costEstimate', 'ownerRole',
   'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime', 
+  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+  'variables', 'inputMappings', 'outputMappings',
   'kpiNotes'
   ],
   'bpmn:SequenceFlow': [


### PR DESCRIPTION
## Summary
- allow gateways to define variables, input mappings, and output mappings

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b49eb112d483289f95fe3a07c3567b