### PR TITLE
Show condition expressions in flow selection dialog

### DIFF
--- a/public/js/components/elements.js
+++ b/public/js/components/elements.js
@@ -487,6 +487,14 @@ function openFlowSelectionModal(flows, themeStream = currentTheme, allowMultiple
     const span = document.createElement('span');
     span.textContent = flow.target?.businessObject?.name || flow.target?.id;
 
+    const condition = flow.businessObject?.conditionExpression?.body;
+    const condSpan = document.createElement('span');
+    condSpan.textContent = ` — ${condition || 'default'}`;
+    condSpan.style.fontSize = '0.8em';
+    condSpan.style.opacity = '0.7';
+
+    span.appendChild(condSpan);
+
     label.appendChild(input);
     label.appendChild(span);
     list.appendChild(label);


### PR DESCRIPTION
## Summary
- Display condition expressions alongside flow names in the selection modal, defaulting when absent
- Add test with minimal DOM stub to ensure modal renders condition text

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_68b4baeebcb88328bbc4959acd8dad6f