### PR TITLE
Require explicit flow selection at exclusive gateways

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -522,14 +522,9 @@ Object.assign(document.body.style, {
   // Prompt user to choose path at gateways
   simulation.pathsStream.subscribe(data => {
     if (!data) return;
-    const { flows, type, isDefaultOnly } = data;
+    const { flows, type } = data;
     if (!flows || !flows.length) return;
     const isInclusive = type === 'bpmn:InclusiveGateway';
-    // If only one flow is viable for exclusive gateways, auto-select it unless it's the default flow
-    if (!isInclusive && flows.length === 1 && !isDefaultOnly) {
-      simulation.step(flows[0].id);
-      return;
-    }
     // Access modal helper via `window` to avoid ReferenceError when used
     // within modules or strict scopes
     window.openFlowSelectionModal(flows, currentTheme, isInclusive).subscribe(chosen => {

--- a/public/js/core/simulation.js
+++ b/public/js/core/simulation.js
@@ -258,19 +258,6 @@ let nextTokenId = 1;
         defaultOnly = true;
       }
 
-      if (viable.length === 1 && !defaultOnly) {
-        const flow = viable[0];
-        const next = {
-          id: token.id,
-          element: flow.target,
-          pendingJoins: token.pendingJoins,
-          viaFlow: flow.id,
-          context: { ...token.context }
-        };
-        logToken(next);
-        return [next];
-      }
-
       pathsStream.set({ flows: viable, type: token.element.type, isDefaultOnly: defaultOnly });
       awaitingToken = token;
       resumeAfterChoice = running;

--- a/tests/simulation/exclusive-gateway.test.js
+++ b/tests/simulation/exclusive-gateway.test.js
@@ -70,12 +70,18 @@ function buildDefaultFlowDiagram() {
   return [start, gw, a, b, f0, f1, f2];
 }
 
-test('exclusive gateway with single conditional flow is taken automatically', () => {
+test('exclusive gateway waits for choice when a single conditional flow is viable', () => {
   const diagram = buildSingleConditionalDiagram();
   const sim = createSimulationInstance(diagram, { delay: 0 });
   sim.reset();
   sim.step(); // start -> gateway
-  sim.step(); // gateway evaluates and takes conditional flow
+  sim.step(); // gateway evaluates and pauses
+  const atGateway = Array.from(sim.tokenStream.get(), t => t.element.id);
+  assert.deepStrictEqual(atGateway, ['gw']);
+  const paths = sim.pathsStream.get();
+  assert.ok(paths);
+  assert.deepStrictEqual(paths.flows.map(f => f.id), ['f1']);
+  sim.step('f1');
   const after = Array.from(sim.tokenStream.get(), t => t.element.id);
   assert.deepStrictEqual(after, ['a']);
   assert.strictEqual(sim.pathsStream.get(), null);

--- a/tests/simulation/undefined-variable.test.js
+++ b/tests/simulation/undefined-variable.test.js
@@ -69,12 +69,18 @@ test('undefined variables evaluate to false by default', () => {
   assert.strictEqual(paths.flows[0].id, 'f2');
 });
 
-test('undefined variables use provided fallback', () => {
+test('undefined variables use provided fallback but still require explicit choice', () => {
   const diagram = buildDiagram();
   const sim = createSimulationInstance(diagram, { delay: 0, conditionFallback: true });
   sim.reset();
   sim.step(); // start -> gateway
-  sim.step(); // evaluate and auto-take conditional flow
+  sim.step(); // evaluate and pause
+  const tokens = Array.from(sim.tokenStream.get(), t => t.element.id);
+  assert.deepStrictEqual(tokens, ['gw']);
+  const paths = sim.pathsStream.get();
+  assert.ok(paths);
+  assert.deepStrictEqual(paths.flows.map(f => f.id), ['f1']);
+  sim.step('f1');
   const after = Array.from(sim.tokenStream.get(), t => t.element.id);
   assert.deepStrictEqual(after, ['a']);
   assert.strictEqual(sim.pathsStream.get(), null);


### PR DESCRIPTION
## Summary
- stop auto-advancing tokens at exclusive gateways; always pause and emit available paths
- always show flow selection modal even when only one path is viable
- add and update tests to ensure gateways wait for an explicit `step` call

## Testing
- `node --test tests/simulation/*.test.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4bdf7a6108328be7062482911a101