### PR TITLE
Allow selecting unsatisfied gateway flows

### DIFF
--- a/public/js/components/elements.js
+++ b/public/js/components/elements.js
@@ -483,7 +483,6 @@ function openFlowSelectionModal(flows, themeStream = currentTheme, allowMultiple
     const input = document.createElement('input');
     input.type = allowMultiple ? 'checkbox' : 'radio';
     input.name = 'flowSelection';
-    input.disabled = !satisfied;
 
     const span = document.createElement('span');
     span.textContent = flow.target?.businessObject?.name || flow.target?.id;
@@ -498,7 +497,11 @@ function openFlowSelectionModal(flows, themeStream = currentTheme, allowMultiple
     span.appendChild(condSpan);
 
     if (!satisfied) {
-      label.style.opacity = '0.5';
+      const unsat = document.createElement('span');
+      unsat.textContent = ' (unsatisfied)';
+      unsat.style.color = 'red';
+      unsat.style.fontSize = '0.8em';
+      span.appendChild(unsat);
     }
 
     label.appendChild(input);


### PR DESCRIPTION
## Summary
- Keep all gateway options selectable in the flow selection modal and show a red “unsatisfied” badge when a condition isn’t met
- Update gateway choice tests to expect enabled options and cover scenarios where all conditions evaluate to false

## Testing
- `node --test tests/simulation/*.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4c32fedd48328ac498c10ae339506