### PR TITLE
Add message flow simulation tests

### DIFF
--- a/tests/simulation/message-flow.test.js
+++ b/tests/simulation/message-flow.test.js
@@ -1,0 +1,95 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadSimulation() {
+  const sandbox = {
+    console,
+    setTimeout,
+    clearTimeout,
+    localStorage: {
+      _data: {},
+      getItem(key) { return this._data[key] || null; },
+      setItem(key, val) { this._data[key] = String(val); },
+      removeItem(key) { delete this._data[key]; }
+    }
+  };
+  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
+  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
+  vm.runInNewContext(streamCode, sandbox);
+  vm.runInNewContext(simulationCode, sandbox);
+  return sandbox.createSimulation;
+}
+
+function createSimulationInstance(elements, opts = {}) {
+  const map = new Map(elements.map(e => [e.id, e]));
+  const elementRegistry = {
+    get(id) { return map.get(id); },
+    filter(fn) { return Array.from(map.values()).filter(fn); }
+  };
+  const canvas = { addMarker() {}, removeMarker() {} };
+  const createSimulation = loadSimulation();
+  return createSimulation({ elementRegistry, canvas }, opts);
+}
+
+function buildDiagram(targetParticipant = false) {
+  const startA = {
+    id: 'Start_A',
+    type: 'bpmn:StartEvent',
+    incoming: [],
+    outgoing: [],
+    businessObject: { $type: 'bpmn:StartEvent' }
+  };
+  const task = { id: 'Task_A', type: 'bpmn:Task', incoming: [], outgoing: [] };
+  const next = { id: 'Task_B', type: 'bpmn:Task', incoming: [], outgoing: [] };
+
+  const f0 = { id: 'Flow_0', type: 'bpmn:SequenceFlow', source: startA, target: task };
+  startA.outgoing = [f0];
+  task.incoming = [f0];
+
+  const fSeq = { id: 'Flow_Seq', type: 'bpmn:SequenceFlow', source: task, target: next };
+  task.outgoing = [fSeq];
+  next.incoming = [fSeq];
+
+  let msgTarget;
+  if (targetParticipant) {
+    msgTarget = { id: 'Participant_B', type: 'bpmn:Participant', incoming: [], outgoing: [] };
+  } else {
+    msgTarget = {
+      id: 'Start_B',
+      type: 'bpmn:StartEvent',
+      incoming: [],
+      outgoing: [],
+      businessObject: { $type: 'bpmn:StartEvent' }
+    };
+  }
+
+  const m1 = { id: 'Message_1', type: 'bpmn:MessageFlow', source: task, target: msgTarget };
+  task.outgoing.push(m1);
+  msgTarget.incoming = [m1];
+
+  return [startA, task, next, msgTarget, f0, fSeq, m1];
+}
+
+test('task sends message and continues along sequence flow', () => {
+  const diagram = buildDiagram(false);
+  const sim = createSimulationInstance(diagram, { delay: 0 });
+  sim.reset();
+  sim.step(); // start -> task
+  sim.step(); // task -> next + message to Start_B
+  const tokens = Array.from(sim.tokenStream.get(), t => t.element && t.element.id).sort();
+  assert.deepStrictEqual(tokens, ['Start_B', 'Task_B'].sort());
+});
+
+test('message flow targeting participant does not spawn token', () => {
+  const diagram = buildDiagram(true);
+  const sim = createSimulationInstance(diagram, { delay: 0 });
+  sim.reset();
+  sim.step(); // start -> task
+  sim.step(); // task -> next (message flow ignored)
+  const tokens = Array.from(sim.tokenStream.get(), t => t.element && t.element.id);
+  assert.deepStrictEqual(tokens, ['Task_B']);
+});
+


### PR DESCRIPTION
## Summary
- add tests verifying tokens for tasks with both sequence and message flows
- ensure message flows targeting participants do not spawn tokens

## Testing
- `node --test tests/simulation/message-flow.test.js`
- `node --test tests/simulation` *(fails: token waits for explicit selection when deliveryStatus matches a single branch, token takes fallback branch after explicit choice when deliveryStatus is unset, exclusive gateway pauses for choice when multiple conditions are true, exclusive gateway exposes flows and waits for explicit choice, exclusive gateway pauses even when only one flow is viable, simulation allows choice when all gateway conditions are unsatisfied, inclusive split/join with single selected path does not wait for others, inclusive split/join waits for all selected branches, inclusive split without gatewayDirection waits for explicit flow selection, undefined variables evaluate to false by default, undefined variables use provided fallback but still require explicit choice)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a9d5e52c83288a814818d75a8d3e