### PR TITLE
Add RACI field definitions to properties panel

### DIFF
--- a/public/js/components/showProperties.js
+++ b/public/js/components/showProperties.js
@@ -227,9 +227,13 @@ const BPMN_PROPERTY_MAP = {
   { key: 'changeOverTime',     label: 'Change Over Time',          type: 'text' },
   { key: 'perCompleteAccurate', label: 'Percent Complete and Accurate',          type: 'text' },
   { key: 'availability ',       label: 'Availability',            type: 'text' },
-  { key: 'leadTime ',           label: 'Lead Time',               type: 'text' },  
+  { key: 'leadTime ',           label: 'Lead Time',               type: 'text' },
   { key: 'kpiNotes',           label: 'KPI Notes',                 type: 'textarea' },
- 
+  { key: 'responsible',       label: 'Responsible',             type: 'text' },
+  { key: 'accountable',       label: 'Accountable',             type: 'text' },
+  { key: 'consulted',         label: 'Consulted',               type: 'text' },
+  { key: 'informed',          label: 'Informed',                type: 'text' },
+
 ];
 
 function openUrlModal(url) {


### PR DESCRIPTION
## Summary
- add Responsible, Accountable, Consulted, and Informed fields to the properties sidebar
- align these fields with existing BPMN property map entries

## Testing
- `npm test` *(fails: Missing script "test")*
- `node test/inclusive-gateway.test.js` *(fails: Cannot read properties of undefined (reading 'element'))*

------
https://chatgpt.com/codex/tasks/task_e_68b5c851c2808328a19dee958ebadbf5