### PR TITLE
Add RACI custom moddle type

### DIFF
--- a/public/js/custom-moddle.json
+++ b/public/js/custom-moddle.json
@@ -24,6 +24,16 @@
         { "name": "default", "type": "String", "isAttr": true },
         { "name": "direction", "type": "String", "isAttr": true }
       ]
+    },
+    {
+      "name": "Raci",
+      "superClass": [ "Element" ],
+      "properties": [
+        { "name": "responsible", "type": "String", "isAttr": true },
+        { "name": "accountable", "type": "String", "isAttr": true },
+        { "name": "consulted",  "type": "String", "isAttr": true },
+        { "name": "informed",   "type": "String", "isAttr": true }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- extend custom moddle descriptor with Raci type for responsibility assignments

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c954f6608328950086815747d0cb