### PR TITLE
feat: export RACI matrix to CSV

### DIFF
--- a/public/js/components/raciMatrix.js
+++ b/public/js/components/raciMatrix.js
@@ -49,7 +49,52 @@
     });
     table.appendChild(tbody);
 
-    return table;
+    const container = document.createElement('div');
+    const buttons = document.createElement('div');
+
+    const exportBtn = document.createElement('button');
+    exportBtn.textContent = 'Export CSV';
+    exportBtn.addEventListener('click', () => {
+      const headers = ['Task','Responsible','Accountable','Consulted','Informed'];
+      const escape = str => `"${String(str).replace(/"/g, '""')}"`;
+      const rows = data.map(item => [
+        escape(item.name || item.id || ''),
+        escape(item.responsible || ''),
+        escape(item.accountable || ''),
+        escape(item.consulted || ''),
+        escape(item.informed || '')
+      ].join(','));
+      const csv = [headers.join(','), ...rows].join('\n');
+      const blob = new Blob([csv], { type: 'text/csv' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'raci-matrix.csv';
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    });
+    buttons.appendChild(exportBtn);
+
+    const printBtn = document.createElement('button');
+    printBtn.textContent = 'Print';
+    printBtn.addEventListener('click', () => {
+      const win = window.open('', '_blank');
+      if (!win) return;
+      win.document.write('<html><head><title>RACI Matrix</title></head><body>');
+      win.document.write(table.outerHTML);
+      win.document.write('</body></html>');
+      win.document.close();
+      win.focus();
+      win.print();
+    });
+    buttons.appendChild(printBtn);
+
+    container.appendChild(buttons);
+    container.appendChild(table);
+
+    return container;
   }
 
   global.raciMatrix = { createRaciMatrix };


### PR DESCRIPTION
## Summary
- add Export CSV and Print controls to RACI matrix modal
- generate CSV from matrix data and download as `raci-matrix.csv`

## Testing
- `node --test` *(fails: TypeError: Cannot read properties of undefined (reading 'element'))*
- `node --test test/raci-serialization.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5df67a3388328b7c7b7bfd4b5d727