### PR TITLE
Use extension elements to derive RACI values

### DIFF
--- a/public/js/components/raciMatrix.js
+++ b/public/js/components/raciMatrix.js
@@ -14,13 +14,15 @@
       .filter(el => !el.labelTarget)
       .map(el => {
         const bo = el.businessObject || {};
+        const raci = (bo.extensionElements?.values || []).find(v => v.$type === 'custom:Raci');
+        const attrs = bo.$attrs || {};
         return {
           id: el.id,
           name: bo.name || '',
-          responsible: bo.responsible || '',
-          accountable: bo.accountable || '',
-          consulted: bo.consulted || '',
-          informed: bo.informed || ''
+          responsible: bo.responsible || raci?.responsible || attrs.responsible || '',
+          accountable: bo.accountable || raci?.accountable || attrs.accountable || '',
+          consulted:  bo.consulted  || raci?.consulted  || attrs.consulted  || '',
+          informed:   bo.informed   || raci?.informed   || attrs.informed   || ''
         };
       });
   }


### PR DESCRIPTION
## Summary
- Derive RACI data from extension elements or $attrs in collectData
- Default missing RACI values to empty strings for consistent table rendering

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5f4d5f98c83288e51fbe347738d0d