### PR TITLE
Prefill RACI values in properties sidebar

### DIFF
--- a/public/js/components/showProperties.js
+++ b/public/js/components/showProperties.js
@@ -763,6 +763,13 @@ function showProperties(element, modeling, moddle) {
 
     let val = bo.get(key);
     if (val == null) {
+      val = bo.$attrs?.[key];
+    }
+    if (val == null && ['responsible','accountable','consulted','informed'].includes(key)) {
+      const raci = (bo.extensionElements?.values || []).find(v => v.$type === 'custom:Raci');
+      val = raci?.[key];
+    }
+    if (val == null) {
       const extEl = bo.extensionElements;
       if (extEl) {
         const ext = (extEl.values || []).find(v => v.$type === 'custom:Attribute' && v.name === key);


### PR DESCRIPTION
## Summary
- Allow showProperties sidebar to pull values from element attributes and custom RACI extension elements so RACI inputs pre-fill

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5f58380f083289ffcdd21d081b82f