### PR TITLE
Maintain RACI attributes and extension

### DIFF
--- a/public/js/components/showProperties.js
+++ b/public/js/components/showProperties.js
@@ -533,6 +533,25 @@ function showProperties(element, modeling, moddle) {
 
       modeling.updateProperties(element, props);
 
+      const raciKeys = ['responsible','accountable','consulted','informed'];
+      bo.$attrs = bo.$attrs || {};
+      let raciEl = (bo.extensionElements?.values || []).find(v => v.$type === 'custom:Raci');
+      if (!raciEl) {
+        const extEl = getOrCreateExtEl(bo, moddle);
+        raciEl = moddle.create('custom:Raci', {});
+        extEl.values.push(raciEl);
+      }
+      raciKeys.forEach(k => {
+        const v = data.get(k) || '';
+        if (v) {
+          bo.$attrs[k] = v;
+          raciEl[k] = v;
+        } else {
+          delete bo.$attrs[k];
+          delete raciEl[k];
+        }
+      });
+
       // handle array-based custom elements
       const extEl = getOrCreateExtEl(bo, moddle);
       arrayKeys.forEach(key => {


### PR DESCRIPTION
## Summary
- Sync RACI fields into both element attributes and custom:Raci extension when saving properties
- Remove blank RACI values from attributes and extension

## Testing
- `node --test` *(fails: TypeError and assertion errors in various simulation tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f6011bf083288ca7756ccdab1d74