### PR TITLE
Fix reactiveImage DOM cleanup

### DIFF
--- a/public/js/components/elements.js
+++ b/public/js/components/elements.js
@@ -141,8 +141,8 @@ function reactiveImage(stream, options = {}, themeStream = currentTheme) {
 
   const unsub1 = themeStream.subscribe(theme => applyStyles(theme));
   applyStyles(themeStream.get());
-  
-  observeDOMRemoval(el, unsub1, unsub2); // 🔥 Auto cleanup when node removed
+
+  observeDOMRemoval(img, unsub1, unsub2); // 🔥 Auto cleanup when node removed
 
   return img;
 }

--- a/test/reactive-image.test.js
+++ b/test/reactive-image.test.js
@@ -1,0 +1,28 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+test('reactiveImage returns an img element', () => {
+  const sandbox = {
+    document: {
+      createElement(tag) {
+        return { tagName: tag, style: {} };
+      }
+    },
+    observeDOMRemoval: () => {},
+    applyTheme: () => {},
+    window: { addEventListener() {}, innerWidth: 1024 },
+  };
+
+  const code = fs.readFileSync(path.resolve(__dirname, '../public/js/components/elements.js'), 'utf8');
+  vm.runInNewContext(code, sandbox);
+
+  const stream = { subscribe(fn) { fn('image.png'); return () => {}; } };
+  const themeStream = { subscribe(fn){ fn({ colors: {} }); return () => {}; }, get(){ return { colors: {} }; } };
+
+  const img = sandbox.reactiveImage(stream, {}, themeStream);
+  assert.ok(img);
+  assert.strictEqual(img.tagName, 'img');
+});


### PR DESCRIPTION
## Summary
- ensure reactiveImage observes cleanup for the image element
- add unit test confirming reactiveImage returns an img element

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --test` *(fails: 19 failing tests)*
- `node --test test/reactive-image.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b76fc8f9148328abb9fb86a18da42f