### PR TITLE
refactor: centralize modal creation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -182,6 +182,7 @@
   <script src="js/core/simulation.js"></script>
   <script src="js/components/elements.js"></script>
   <script src="js/components/layout.js"></script>
+  <script src="js/components/modal.js"></script>
   <script src="js/components/diagramTree.js"></script>
   <script src="js/components/showProperties.js"></script>
   <script src="js/components/addOnFilter.js"></script>

--- a/public/js/components/modal.js
+++ b/public/js/components/modal.js
@@ -1,0 +1,49 @@
+(function(global) {
+  function createModal(themeStream = currentTheme, onClose = () => {}) {
+    const theme = themeStream.get ? themeStream.get() : themeStream;
+    const colors = theme.colors || {};
+
+    const modal = document.createElement('div');
+    Object.assign(modal.style, {
+      position: 'fixed',
+      top: '0',
+      left: '0',
+      width: '100vw',
+      height: '100vh',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: 'rgba(0, 0, 0, 0.5)',
+      zIndex: '9999'
+    });
+
+    const content = document.createElement('div');
+    content.classList.add('responsive-modal');
+    Object.assign(content.style, {
+      padding: '2rem',
+      borderRadius: '8px',
+      boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+      maxWidth: '90%',
+      backgroundColor: colors.surface || '#fff',
+      color: colors.foreground || '#000',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '1rem'
+    });
+
+    modal.appendChild(content);
+    document.body.appendChild(modal);
+
+    modal.addEventListener('click', e => {
+      if (e.target === modal) {
+        onClose();
+        modal.remove();
+      }
+    });
+
+    return { modal, content };
+  }
+
+  global.createModal = createModal;
+})(window);
+

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -21,31 +21,7 @@ function reactiveLoginModal(themeStream = currentTheme) {
   const emailStream = new Stream('');
   const passwordStream = new Stream('');
 
-  // Modal container
-  const modal = document.createElement('div');
-  modal.style.position = 'fixed';
-  modal.style.top = '0';
-  modal.style.left = '0';
-  modal.style.width = '100vw';
-  modal.style.height = '100vh';
-  modal.style.display = 'flex';
-  modal.style.alignItems = 'center';
-  modal.style.justifyContent = 'center';
-  modal.style.backgroundColor = 'rgba(0, 0, 0, 0.5)';
-  modal.style.zIndex = '9999';
-
-  // Modal content box
-  const content = document.createElement('div');
-  content.classList.add('responsive-modal');
-  content.style.padding = '2rem';
-  content.style.borderRadius = '8px';
-  content.style.boxShadow = '0 4px 12px rgba(0,0,0,0.3)';
-  content.style.maxWidth = '90%';
-  content.style.backgroundColor = themeStream.get().colors.surface || '#fff';
-  content.style.color = themeStream.get().colors.foreground || '#000';
-  content.style.display = 'flex';
-  content.style.flexDirection = 'column';
-  content.style.gap = '1rem';
+  const { modal, content } = createModal(themeStream, () => loginStream.set(null));
 
   const title = document.createElement('h2');
   title.textContent = 'Log in to Flow Control Center';
@@ -128,17 +104,6 @@ function reactiveLoginModal(themeStream = currentTheme) {
   btnRow.appendChild(loginBtn);
   content.appendChild(btnRow);
 
-  modal.appendChild(content);
-  document.body.appendChild(modal);
-
-  // Close on outside click
-  modal.addEventListener('click', (e) => {
-    if (e.target === modal) {
-      loginStream.set(null);
-      modal.remove();
-    }
-  });
-
   return loginStream;
 }
 
@@ -147,33 +112,9 @@ function reactiveLoginModal(themeStream = currentTheme) {
 function openDiagramPickerModal(themeStream = currentTheme) {
   const pickStream = new Stream(null); // emits selected diagram or null
 
-  // Modal base
-  const modal = document.createElement('div');
-  modal.style.position = 'fixed';
-  modal.style.top = '0';
-  modal.style.left = '0';
-  modal.style.width = '100vw';
-  modal.style.height = '100vh';
-  modal.style.display = 'flex';
-  modal.style.alignItems = 'center';
-  modal.style.justifyContent = 'center';
-  modal.style.backgroundColor = 'rgba(0, 0, 0, 0.5)';
-  modal.style.zIndex = '9999';
-
-  // Content box
-  const content = document.createElement('div');
-  content.classList.add('responsive-modal');
-  content.style.padding = '2rem';
-  content.style.borderRadius = '8px';
-  content.style.boxShadow = '0 4px 12px rgba(0,0,0,0.3)';
-  content.style.maxWidth = '90%';
+  const { modal, content } = createModal(themeStream, () => pickStream.set(null));
   content.style.maxHeight = '80vh';
   content.style.overflowY = 'auto';
-  content.style.backgroundColor = themeStream.get().colors.surface || '#fff';
-  content.style.color = themeStream.get().colors.foreground || '#000';
-  content.style.display = 'flex';
-  content.style.flexDirection = 'column';
-  content.style.gap = '1rem';
 
   const title = document.createElement('h2');
   title.textContent = 'Select a Diagram';
@@ -317,16 +258,6 @@ function openDiagramPickerModal(themeStream = currentTheme) {
   btnRow.appendChild(cancelBtn);
   btnRow.appendChild(newBtn);
   content.appendChild(btnRow);
-
-  modal.appendChild(content);
-  document.body.appendChild(modal);
-
-  modal.addEventListener('click', (e) => {
-    if (e.target === modal) {
-      pickStream.set(null);
-      modal.remove();
-    }
-  });
 
   return pickStream;
 }


### PR DESCRIPTION
## Summary
- create a reusable `createModal` helper that builds a themed modal and handles outside-click closing
- refactor login and diagram picker modals to use the shared modal utility
- include new modal helper in app HTML

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b77352f0188328b1456887d5e17f90