### PR TITLE
refactor: add blockchain init helper

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -248,22 +248,23 @@ Object.assign(document.body.style, {
   let blockchainPersistPromise = Promise.resolve();
   window.blockchain = blockchain;
 
-  const origStart = simulation.start;
-  simulation.start = (...args) => {
+  function initBlockchain() {
     tokenPanel.hide();
     blockchain = new Blockchain();
     window.blockchain = blockchain;
     processedTokens = 0;
+  }
+
+  const origStart = simulation.start;
+  simulation.start = (...args) => {
+    initBlockchain();
     tokenPanel.show();
     return origStart.apply(simulation, args);
   };
 
   const origReset = simulation.reset;
   simulation.reset = (...args) => {
-    tokenPanel.hide();
-    blockchain = new Blockchain();
-    window.blockchain = blockchain;
-    processedTokens = 0;
+    initBlockchain();
     const res = origReset.apply(simulation, args);
     return res;
   };


### PR DESCRIPTION
## Summary
- factor out repeated blockchain initialization into `initBlockchain`
- reuse `initBlockchain` within `simulation.start` and `simulation.reset`

## Testing
- `node --test tests/simulation/blockchain-simulation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b82ab30cdc832885be56c8018bfd8a