### PR TITLE
chore: remove unused grid and spacer functions

### DIFF
--- a/public/js/components/layout.js
+++ b/public/js/components/layout.js
@@ -63,41 +63,6 @@ function container(child, options = {}, themeStream = currentTheme) {
   return div;
 }
 
-
-
-
-// 📐 Grid: CSS Grid Layout
-function grid(children = [], options = {}, themeStream = currentTheme) {
-  const el = document.createElement('div');
-  el.style.display = 'grid';
-
-  // Default: 2-column responsive grid
-  el.style.gridTemplateColumns = options.columns || 'repeat(auto-fit, minmax(200px, 1fr))';
-  el.style.gap = options.gap || '1rem';
-
-  children.forEach(child => el.appendChild(child));
-
-  themeStream.subscribe(theme => {
-    if (options.bg || options.border) {
-      el.style.backgroundColor = options.bg || theme.colors.primary;
-      el.style.border = options.border || 'none';
-      el.style.padding = options.padding || '1rem';
-      el.style.borderRadius = options.radius || '0.5rem';
-    }
-  });
-
-  return el;
-}
-
-// 🔲 Spacer: Flexible or fixed space
-function spacer(options = {}) {
-  const el = document.createElement('div');
-  el.style.flexGrow = options.flexGrow || '1';
-  el.style.width = options.width || 'auto';
-  el.style.height = options.height || '1rem';
-  return el;
-}
-
 // ➖ Divider: Horizontal or vertical line
 function divider(options = {}, themeStream = currentTheme) {
   const el = document.createElement('div');


### PR DESCRIPTION
## Summary
- remove grid and spacer helpers from layout.js
- clean up unused layout utilities

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b83a0c0ecc8328ac69573ac975074e