### PR TITLE
refactor: remove peer management from blockchain

### DIFF
--- a/public/js/blockchain.js
+++ b/public/js/blockchain.js
@@ -97,14 +97,7 @@ class Blockchain {
   reset() {
     this.chain = [this.createGenesisBlock()];
     this.persist();
-    this.peers = [];
     this.difficulty = 2;
-  }
-
-  addPeer(url) {
-    if (!this.peers.includes(url)) {
-      this.peers.push(url);
-    }
   }
 
   broadcastBlock(block) {


### PR DESCRIPTION
## Summary
- remove unused peer reset and addPeer method from blockchain implementation
- retain broadcast functionality using constructor-provided peer list

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b83bba4fd88328bca7cb07f903ffb2