### PR TITLE
test: centralize simulation helper

### DIFF
--- a/tests/helpers/simulation.js
+++ b/tests/helpers/simulation.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadSimulation(extra = {}) {
+  const sandbox = {
+    console,
+    setTimeout,
+    clearTimeout,
+    localStorage: {
+      _data: {},
+      getItem(key) { return this._data[key] || null; },
+      setItem(key, val) { this._data[key] = String(val); },
+      removeItem(key) { delete this._data[key]; }
+    },
+    ...extra
+  };
+  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
+  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
+  vm.runInNewContext(streamCode, sandbox);
+  vm.runInNewContext(simulationCode, sandbox);
+  return sandbox;
+}
+
+function createSimulationInstance(elements, opts = {}, sandbox, context) {
+  const env = sandbox || loadSimulation();
+  const map = new Map(elements.map(e => [e.id, e]));
+  const elementRegistry = {
+    get(id) { return map.get(id); },
+    filter(fn) { return Array.from(map.values()).filter(fn); }
+  };
+  for (const el of map.values()) {
+    if (!el.type && el.source && el.target) {
+      el.type = 'bpmn:SequenceFlow';
+    }
+  }
+  const canvas = { addMarker() {}, removeMarker() {} };
+  const config = { elementRegistry, canvas };
+  if (context !== undefined) {
+    config.context = context;
+  }
+  const sim = env.createSimulation(config, opts);
+  sim.canvas = canvas;
+  return sim;
+}
+
+module.exports = { loadSimulation, createSimulationInstance };

--- a/tests/simulation/delivery-gateway.test.js
+++ b/tests/simulation/delivery-gateway.test.js
@@ -1,38 +1,6 @@
 const { test } = require('node:test');
 const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
-
-function loadSimulation() {
-  const sandbox = {
-    console,
-    setTimeout,
-    clearTimeout,
-    localStorage: {
-      _data: {},
-      getItem(key) { return this._data[key] || null; },
-      setItem(key, val) { this._data[key] = String(val); },
-      removeItem(key) { delete this._data[key]; }
-    }
-  };
-  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
-  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
-  vm.runInNewContext(streamCode, sandbox);
-  vm.runInNewContext(simulationCode, sandbox);
-  return sandbox.createSimulation;
-}
-
-function createSimulationInstance(elements, opts = {}) {
-  const map = new Map(elements.map(e => [e.id, e]));
-  const elementRegistry = {
-    get(id) { return map.get(id); },
-    filter(fn) { return Array.from(map.values()).filter(fn); }
-  };
-  const canvas = { addMarker() {}, removeMarker() {} };
-  const createSimulation = loadSimulation();
-  return createSimulation({ elementRegistry, canvas }, opts);
-}
+const { createSimulationInstance } = require('../helpers/simulation');
 
 function buildDeliveryCheckDiagram() {
   const start = { id: 'start', type: 'bpmn:StartEvent', outgoing: [], incoming: [], businessObject: { $type: 'bpmn:StartEvent' } };

--- a/tests/simulation/exclusive-gateway-autoselect.test.js
+++ b/tests/simulation/exclusive-gateway-autoselect.test.js
@@ -1,38 +1,6 @@
 const { test } = require('node:test');
 const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
-
-function loadSimulation() {
-  const sandbox = {
-    console,
-    setTimeout,
-    clearTimeout,
-    localStorage: {
-      _data: {},
-      getItem(key) { return this._data[key] || null; },
-      setItem(key, val) { this._data[key] = String(val); },
-      removeItem(key) { delete this._data[key]; }
-    }
-  };
-  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
-  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
-  vm.runInNewContext(streamCode, sandbox);
-  vm.runInNewContext(simulationCode, sandbox);
-  return sandbox.createSimulation;
-}
-
-function createSimulationInstance(elements, opts = {}) {
-  const map = new Map(elements.map(e => [e.id, e]));
-  const elementRegistry = {
-    get(id) { return map.get(id); },
-    filter(fn) { return Array.from(map.values()).filter(fn); }
-  };
-  const canvas = { addMarker() {}, removeMarker() {} };
-  const createSimulation = loadSimulation();
-  return createSimulation({ elementRegistry, canvas }, opts);
-}
+const { createSimulationInstance } = require('../helpers/simulation');
 
 function buildDiagram() {
   const start = { id: 'start', type: 'bpmn:StartEvent', outgoing: [], incoming: [], businessObject: { $type: 'bpmn:StartEvent' } };

--- a/tests/simulation/exclusive-gateway-choice.test.js
+++ b/tests/simulation/exclusive-gateway-choice.test.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const { createSimulationInstance } = require('../helpers/simulation');
 
 class Element {
   constructor(tag) {
@@ -67,35 +68,6 @@ class Document {
   }
 }
 
-function loadSimulation() {
-  const sandbox = {
-    console,
-    setTimeout,
-    clearTimeout,
-    localStorage: {
-      _data: {},
-      getItem(key) { return this._data[key] || null; },
-      setItem(key, val) { this._data[key] = String(val); },
-      removeItem(key) { delete this._data[key]; }
-    }
-  };
-  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
-  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
-  vm.runInNewContext(streamCode, sandbox);
-  vm.runInNewContext(simulationCode, sandbox);
-  return sandbox.createSimulation;
-}
-
-function createSimulationInstance(elements, opts = {}) {
-  const map = new Map(elements.map(e => [e.id, e]));
-  const elementRegistry = {
-    get(id) { return map.get(id); },
-    filter(fn) { return Array.from(map.values()).filter(fn); }
-  };
-  const canvas = { addMarker() {}, removeMarker() {} };
-  const createSimulation = loadSimulation();
-  return createSimulation({ elementRegistry, canvas }, opts);
-}
 
 function buildDiagram() {
   const start = { id: 'start', type: 'bpmn:StartEvent', outgoing: [], incoming: [], businessObject: { $type: 'bpmn:StartEvent' } };

--- a/tests/simulation/exclusive-gateway.multiple.test.js
+++ b/tests/simulation/exclusive-gateway.multiple.test.js
@@ -1,38 +1,6 @@
 const { test } = require('node:test');
 const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
-
-function loadSimulation() {
-  const sandbox = {
-    console,
-    setTimeout,
-    clearTimeout,
-    localStorage: {
-      _data: {},
-      getItem(key) { return this._data[key] || null; },
-      setItem(key, val) { this._data[key] = String(val); },
-      removeItem(key) { delete this._data[key]; }
-    }
-  };
-  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
-  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
-  vm.runInNewContext(streamCode, sandbox);
-  vm.runInNewContext(simulationCode, sandbox);
-  return sandbox.createSimulation;
-}
-
-function createSimulationInstance(elements, opts = {}) {
-  const map = new Map(elements.map(e => [e.id, e]));
-  const elementRegistry = {
-    get(id) { return map.get(id); },
-    filter(fn) { return Array.from(map.values()).filter(fn); }
-  };
-  const canvas = { addMarker() {}, removeMarker() {} };
-  const createSimulation = loadSimulation();
-  return createSimulation({ elementRegistry, canvas }, opts);
-}
+const { createSimulationInstance } = require('../helpers/simulation');
 
 function buildMultipleConditionalDiagram() {
   const start = { id: 'start', type: 'bpmn:StartEvent', outgoing: [], incoming: [], businessObject: { $type: 'bpmn:StartEvent' } };

--- a/tests/simulation/exclusive-gateway.test.js
+++ b/tests/simulation/exclusive-gateway.test.js
@@ -1,38 +1,6 @@
 const { test } = require('node:test');
 const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
-
-function loadSimulation() {
-  const sandbox = {
-    console,
-    setTimeout,
-    clearTimeout,
-    localStorage: {
-      _data: {},
-      getItem(key) { return this._data[key] || null; },
-      setItem(key, val) { this._data[key] = String(val); },
-      removeItem(key) { delete this._data[key]; }
-    }
-  };
-  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
-  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
-  vm.runInNewContext(streamCode, sandbox);
-  vm.runInNewContext(simulationCode, sandbox);
-  return sandbox.createSimulation;
-}
-
-function createSimulationInstance(elements, opts = {}) {
-  const map = new Map(elements.map(e => [e.id, e]));
-  const elementRegistry = {
-    get(id) { return map.get(id); },
-    filter(fn) { return Array.from(map.values()).filter(fn); }
-  };
-  const canvas = { addMarker() {}, removeMarker() {} };
-  const createSimulation = loadSimulation();
-  return createSimulation({ elementRegistry, canvas }, opts);
-}
+const { createSimulationInstance } = require('../helpers/simulation');
 
 function buildSingleConditionalDiagram() {
   const start = { id: 'start', type: 'bpmn:StartEvent', outgoing: [], incoming: [], businessObject: { $type: 'bpmn:StartEvent' } };

--- a/tests/simulation/flow-markers.test.js
+++ b/tests/simulation/flow-markers.test.js
@@ -1,44 +1,6 @@
 const { test } = require('node:test');
 const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
-
-function loadSimulation() {
-  const sandbox = {
-    console,
-    setTimeout,
-    clearTimeout,
-    localStorage: {
-      _data: {},
-      getItem(key) { return this._data[key] || null; },
-      setItem(key, val) { this._data[key] = String(val); },
-      removeItem(key) { delete this._data[key]; }
-    }
-  };
-  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
-  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
-  vm.runInNewContext(streamCode, sandbox);
-  vm.runInNewContext(simulationCode, sandbox);
-  return sandbox.createSimulation;
-}
-
-function createSimulationInstance(elements, opts = {}) {
-  const map = new Map(elements.map(e => [e.id, e]));
-  const elementRegistry = {
-    get(id) { return map.get(id); },
-    filter(fn) { return Array.from(map.values()).filter(fn); }
-  };
-  const canvas = {
-    added: [],
-    removed: [],
-    addMarker(id, marker) { this.added.push([id, marker]); },
-    removeMarker(id, marker) { this.removed.push([id, marker]); }
-  };
-  const createSimulation = loadSimulation();
-  const sim = createSimulation({ elementRegistry, canvas }, opts);
-  return { sim, canvas };
-}
+const { createSimulationInstance } = require('../helpers/simulation');
 
 function buildSimpleDiagram() {
   const start = { id: 'start', type: 'bpmn:StartEvent', outgoing: [], incoming: [], businessObject: { $type: 'bpmn:StartEvent' } };
@@ -50,11 +12,14 @@ function buildSimpleDiagram() {
 }
 
 test('sequence flow receives active marker when token passes through it', () => {
-  const { sim, canvas } = createSimulationInstance(buildSimpleDiagram(), { delay: 0 });
-  sim.reset();
+  const sim = createSimulationInstance(buildSimpleDiagram(), { delay: 0 });
+  const { canvas } = sim;
   canvas.added = [];
   canvas.removed = [];
-
+  canvas.addMarker = function(id, marker) { this.added.push([id, marker]); };
+  canvas.removeMarker = function(id, marker) { this.removed.push([id, marker]); };
+  sim.reset();
+  
   // start -> task via f0
   sim.step();
   assert.ok(canvas.added.some(([id, marker]) => id === 'f0' && marker === 'active'));

--- a/tests/simulation/inclusive-gateway-missing-direction.test.js
+++ b/tests/simulation/inclusive-gateway-missing-direction.test.js
@@ -1,38 +1,6 @@
 const { test } = require('node:test');
 const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
-
-function loadSimulation() {
-  const sandbox = {
-    console,
-    setTimeout,
-    clearTimeout,
-    localStorage: {
-      _data: {},
-      getItem(key) { return this._data[key] || null; },
-      setItem(key, val) { this._data[key] = String(val); },
-      removeItem(key) { delete this._data[key]; }
-    }
-  };
-  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
-  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
-  vm.runInNewContext(streamCode, sandbox);
-  vm.runInNewContext(simulationCode, sandbox);
-  return sandbox.createSimulation;
-}
-
-function createSimulationInstance(elements, opts = {}) {
-  const map = new Map(elements.map(e => [e.id, e]));
-  const elementRegistry = {
-    get(id) { return map.get(id); },
-    filter(fn) { return Array.from(map.values()).filter(fn); }
-  };
-  const canvas = { addMarker() {}, removeMarker() {} };
-  const createSimulation = loadSimulation();
-  return createSimulation({ elementRegistry, canvas }, opts);
-}
+const { createSimulationInstance } = require('../helpers/simulation');
 
 function buildDiagram() {
   const start = { id: 'start', type: 'bpmn:StartEvent', outgoing: [], incoming: [], businessObject: { $type: 'bpmn:StartEvent' } };

--- a/tests/simulation/inclusive-split-join.test.js
+++ b/tests/simulation/inclusive-split-join.test.js
@@ -1,38 +1,6 @@
 const { test } = require('node:test');
 const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
-
-function loadSimulation() {
-  const sandbox = {
-    console,
-    setTimeout,
-    clearTimeout,
-    localStorage: {
-      _data: {},
-      getItem(key) { return this._data[key] || null; },
-      setItem(key, val) { this._data[key] = String(val); },
-      removeItem(key) { delete this._data[key]; }
-    }
-  };
-  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
-  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
-  vm.runInNewContext(streamCode, sandbox);
-  vm.runInNewContext(simulationCode, sandbox);
-  return sandbox.createSimulation;
-}
-
-function createSimulationInstance(elements, opts = {}) {
-  const map = new Map(elements.map(e => [e.id, e]));
-  const elementRegistry = {
-    get(id) { return map.get(id); },
-    filter(fn) { return Array.from(map.values()).filter(fn); }
-  };
-  const canvas = { addMarker() {}, removeMarker() {} };
-  const createSimulation = loadSimulation();
-  return createSimulation({ elementRegistry, canvas }, opts);
-}
+const { createSimulationInstance } = require('../helpers/simulation');
 
 function buildSplitJoinDiagram(extraTaskOnB = false, omitDirection = false) {
   const start = { id: 'start', type: 'bpmn:StartEvent', outgoing: [], incoming: [], businessObject: { $type: 'bpmn:StartEvent' } };

--- a/tests/simulation/message-flow.test.js
+++ b/tests/simulation/message-flow.test.js
@@ -1,38 +1,6 @@
 const { test } = require('node:test');
 const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
-
-function loadSimulation() {
-  const sandbox = {
-    console,
-    setTimeout,
-    clearTimeout,
-    localStorage: {
-      _data: {},
-      getItem(key) { return this._data[key] || null; },
-      setItem(key, val) { this._data[key] = String(val); },
-      removeItem(key) { delete this._data[key]; }
-    }
-  };
-  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
-  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
-  vm.runInNewContext(streamCode, sandbox);
-  vm.runInNewContext(simulationCode, sandbox);
-  return sandbox.createSimulation;
-}
-
-function createSimulationInstance(elements, opts = {}) {
-  const map = new Map(elements.map(e => [e.id, e]));
-  const elementRegistry = {
-    get(id) { return map.get(id); },
-    filter(fn) { return Array.from(map.values()).filter(fn); }
-  };
-  const canvas = { addMarker() {}, removeMarker() {} };
-  const createSimulation = loadSimulation();
-  return createSimulation({ elementRegistry, canvas }, opts);
-}
+const { createSimulationInstance } = require('../helpers/simulation');
 
 function buildDiagram(targetParticipant = false) {
   const startA = {

--- a/tests/simulation/undefined-variable.test.js
+++ b/tests/simulation/undefined-variable.test.js
@@ -1,38 +1,6 @@
 const { test } = require('node:test');
 const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
-
-function loadSimulation() {
-  const sandbox = {
-    console,
-    setTimeout,
-    clearTimeout,
-    localStorage: {
-      _data: {},
-      getItem(key) { return this._data[key] || null; },
-      setItem(key, val) { this._data[key] = String(val); },
-      removeItem(key) { delete this._data[key]; }
-    }
-  };
-  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
-  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
-  vm.runInNewContext(streamCode, sandbox);
-  vm.runInNewContext(simulationCode, sandbox);
-  return sandbox.createSimulation;
-}
-
-function createSimulationInstance(elements, opts = {}, context = {}) {
-  const map = new Map(elements.map(e => [e.id, e]));
-  const elementRegistry = {
-    get(id) { return map.get(id); },
-    filter(fn) { return Array.from(map.values()).filter(fn); }
-  };
-  const canvas = { addMarker() {}, removeMarker() {} };
-  const createSimulation = loadSimulation();
-  return createSimulation({ elementRegistry, canvas, context }, opts);
-}
+const { createSimulationInstance } = require('../helpers/simulation');
 
 function buildDiagram() {
   const start = { id: 'start', type: 'bpmn:StartEvent', outgoing: [], incoming: [], businessObject: { $type: 'bpmn:StartEvent' } };


### PR DESCRIPTION
## Summary
- extract loadSimulation and createSimulationInstance into tests/helpers/simulation
- refactor simulation tests to use shared helper
- adjust flow marker test to track markers

## Testing
- `node --test tests/simulation`


------
https://chatgpt.com/codex/tasks/task_e_68b83d8e507c83289896f5d9462b68af