### PR TITLE
refactor: modularize app sections

### DIFF
--- a/public/js/addOnFiltering.js
+++ b/public/js/addOnFiltering.js
@@ -1,0 +1,104 @@
+export function initAddOnFiltering({ currentTheme, elementRegistry, modeling, canvas, scheduleOverlayUpdate, addOnStore, diagramXMLStream, typeIcons }) {
+  const { createAddOnFilterPanel, selectedType, selectedSubtype } = window.addOnFilter;
+  let addOnFilterPanelEl = null;
+
+  const filterToggleBtn = document.createElement('button');
+  filterToggleBtn.textContent = 'Filters';
+  filterToggleBtn.classList.add('addon-filter-toggle');
+
+  filterToggleBtn.addEventListener('click', () => {
+    if (!addOnFilterPanelEl) {
+      addOnFilterPanelEl = createAddOnFilterPanel(currentTheme);
+      document.body.appendChild(addOnFilterPanelEl);
+    }
+    const isVisible = addOnFilterPanelEl.style.display === 'flex';
+    if (isVisible) {
+      selectedType.set(null);
+      selectedSubtype.set(null);
+    }
+    addOnFilterPanelEl.style.display = isVisible ? 'none' : 'flex';
+  });
+
+  if (window.addOnLegend) {
+    const legendEl = addOnLegend.createAddOnLegend(typeIcons, currentTheme);
+    legendEl.prepend(filterToggleBtn);
+    document.body.appendChild(legendEl);
+  }
+
+  const highlightedNodes = new Set();
+  function updateHighlightedNodes() {
+    highlightedNodes.forEach(id => canvas.removeMarker(id, 'bpmn-addOn-highlight'));
+    highlightedNodes.clear();
+    const type = selectedType.get();
+    if (!type || !addOnStore) return;
+    const subtype = selectedSubtype.get();
+    const nodeIds = subtype ? addOnStore.findNodesBySubtype(type, subtype) : addOnStore.findNodesByType(type);
+    nodeIds.forEach(id => {
+      canvas.addMarker(id, 'bpmn-addOn-highlight');
+      highlightedNodes.add(id);
+    });
+  }
+
+  selectedType.subscribe(() => { updateHighlightedNodes(); scheduleOverlayUpdate(); });
+  selectedSubtype.subscribe(() => { updateHighlightedNodes(); scheduleOverlayUpdate(); });
+
+  if (addOnStore) {
+    const originalSetAddOns = addOnStore.setAddOns;
+    const originalClear = addOnStore.clear;
+    addOnStore.setAddOns = function(nodeId, addOns) {
+      originalSetAddOns(nodeId, addOns);
+      scheduleOverlayUpdate();
+      updateHighlightedNodes();
+    };
+    addOnStore.clear = function() {
+      originalClear();
+      scheduleOverlayUpdate();
+      updateHighlightedNodes();
+    };
+  }
+
+  function syncAddOnStoreFromElements() {
+    if (!addOnStore) return;
+    addOnStore.clear();
+    elementRegistry.getAll().forEach(el => {
+      const bo = el.businessObject;
+      const raw = bo?.$attrs?.addOns || bo?.addOns;
+      if (raw) {
+        try {
+          const data = typeof raw === 'string' ? JSON.parse(raw) : raw;
+          addOnStore.setAddOns(bo.id, data);
+        } catch (err) {
+          console.warn('Failed to parse addOns for', bo.id, err);
+        }
+      }
+    });
+  }
+
+  function applyAddOnsToElements(data) {
+    Object.entries(data || {}).forEach(([id, addOns]) => {
+      const el = elementRegistry.get(id);
+      if (el) {
+        modeling.updateProperties(el, { addOns: JSON.stringify(addOns) });
+      }
+    });
+  }
+
+  function loadAddOnData(data = {}) {
+    if (!addOnStore) return;
+    addOnStore.clear();
+    Object.entries(data || {}).forEach(([id, addOns]) => {
+      addOnStore.setAddOns(id, addOns);
+    });
+    applyAddOnsToElements(data);
+    scheduleOverlayUpdate();
+    updateHighlightedNodes();
+  }
+
+  diagramXMLStream.subscribe(() => {
+    syncAddOnStoreFromElements();
+    scheduleOverlayUpdate();
+    updateHighlightedNodes();
+  });
+
+  return { loadAddOnData, applyAddOnsToElements, syncAddOnStoreFromElements };
+}

--- a/public/js/addOnOverlays.js
+++ b/public/js/addOnOverlays.js
@@ -1,0 +1,54 @@
+export function initAddOnOverlays({ overlays, elementRegistry, typeIcons }) {
+  let addOnOverlayIds = [];
+
+  function updateAddOnOverlays() {
+    addOnOverlayIds.forEach(id => overlays.remove(id));
+    addOnOverlayIds = [];
+    const processed = new Set();
+    elementRegistry.getAll().forEach(el => {
+      if (el.type === 'label' || el.labelTarget) return;
+      const bo = el.businessObject;
+      const elementId = bo?.id;
+      if (!elementId || processed.has(elementId)) return;
+      processed.add(elementId);
+      const raw = bo?.$attrs?.addOns || bo?.addOns;
+      if (!raw) return;
+      let addOns;
+      try {
+        addOns = typeof raw === 'string' ? JSON.parse(raw) : raw;
+      } catch (err) {
+        return;
+      }
+      if (!Array.isArray(addOns) || !addOns.length) return;
+      const icons = addOns
+        .map(a => typeIcons[a.type] || '')
+        .filter(Boolean)
+        .join('');
+      if (!icons) return;
+      const badge = document.createElement('div');
+      badge.className = 'addon-overlay';
+      badge.style.background = 'rgba(255, 255, 255, 0.8)';
+      badge.style.borderRadius = '4px';
+      badge.style.padding = '2px';
+      badge.style.fontSize = '14px';
+      badge.innerText = icons;
+      const overlayId = overlays.add(el, {
+        position: { top: -10, left: -10 },
+        html: badge
+      });
+      addOnOverlayIds.push(overlayId);
+    });
+  }
+
+  let overlayUpdateScheduled = false;
+  function scheduleOverlayUpdate() {
+    if (overlayUpdateScheduled) return;
+    overlayUpdateScheduled = true;
+    setTimeout(() => {
+      overlayUpdateScheduled = false;
+      updateAddOnOverlays();
+    }, 0);
+  }
+
+  return { scheduleOverlayUpdate, updateAddOnOverlays };
+}

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -1,0 +1,41 @@
+export const logUser = new Stream('👤 Login');
+export let currentUser = null;
+window.currentUser = currentUser;
+
+export function authMenuOption({ avatarStream, showSaveButton, currentTheme, rebuildMenu }) {
+  return {
+    label: logUser.get(),
+    onClick: () => {
+      if (currentUser) {
+        firebase.auth().signOut().then(() => {
+          logUser.set('👤 Login');
+          avatarStream.set('flow.png');
+          showSaveButton.set(false);
+          currentUser = null;
+          window.currentUser = currentUser;
+          rebuildMenu();
+        }).catch(() => {
+          if (window.showToast) {
+            window.showToast('Logout failed: ', { type: 'error' });
+          }
+        });
+      } else {
+        const userStream = window.reactiveLoginModal(currentTheme);
+        userStream.subscribe(result => {
+          if (result instanceof Error) {
+            if (window.showToast) {
+              window.showToast(`Error: ${result.message}`, { type: 'error' });
+            }
+          } else if (result) {
+            currentUser = result;
+            window.currentUser = currentUser;
+            logUser.set('👤 Logout');
+            avatarStream.set('flowLoggedIn.png');
+            showSaveButton.set(true);
+            rebuildMenu();
+          }
+        });
+      }
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- split authentication into `auth.js`
- encapsulate add-on overlays and filtering in dedicated modules
- wire new modules into main application

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b84160e56c832897765f873e4d8638