### PR TITLE
chore: use inherits-browser for attach-boundary

### DIFF
--- a/public/features/attach-boundary/index.js
+++ b/public/features/attach-boundary/index.js
@@ -1,6 +1,6 @@
 import { isAny } from 'bpmn-js/lib/features/modeling/util/ModelingUtil';
 import { is } from 'bpmn-js/lib/util/ModelUtil';
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 import RuleProvider from 'diagram-js/lib/features/rules/RuleProvider';
 
 export default {

--- a/src/features/attach-boundary/index.js
+++ b/src/features/attach-boundary/index.js
@@ -1,6 +1,6 @@
 import { isAny } from 'bpmn-js/lib/features/modeling/util/ModelingUtil';
 import { is } from 'bpmn-js/lib/util/ModelUtil';
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 import RuleProvider from 'diagram-js/lib/features/rules/RuleProvider';
 
 export default {


### PR DESCRIPTION
## Summary
- use `inherits-browser` in attach-boundary feature modules

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'element'))*

------
https://chatgpt.com/codex/tasks/task_e_68bb392231e883289d36b4e4b8ca5338